### PR TITLE
Release main/Smdn.Net.MuninNode-1.2.0

### DIFF
--- a/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-1.1.0)
+// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-1.2.0)
 //   Name: Smdn.Net.MuninNode
-//   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0+8c512e91195981258988a30fdf9c0ff4c53a6acc
+//   AssemblyVersion: 1.2.0.0
+//   InformationalVersion: 1.2.0+b0e11cd6b408018ad93f29b49e58cab7e9ef6b1b
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -33,6 +33,8 @@ using Smdn.Net.MuninPlugin;
 
 namespace Smdn.Net.MuninNode {
   public class LocalNode : NodeBase {
+    public LocalNode(IPluginProvider pluginProvider, string hostName, int port, ILogger? logger = null) {}
+    public LocalNode(IPluginProvider pluginProvider, string hostName, int port, IServiceProvider? serviceProvider = null) {}
     public LocalNode(IReadOnlyCollection<IPlugin> plugins, int port, IServiceProvider? serviceProvider = null) {}
     public LocalNode(IReadOnlyCollection<IPlugin> plugins, string hostName, int port, IServiceProvider? serviceProvider = null) {}
 
@@ -46,11 +48,21 @@ namespace Smdn.Net.MuninNode {
     IAsyncDisposable,
     IDisposable
   {
+    private protected class PluginProvider : IPluginProvider {
+      public PluginProvider(IReadOnlyCollection<IPlugin> plugins) {}
+
+      public IReadOnlyCollection<IPlugin> Plugins { get; }
+      public INodeSessionCallback? SessionCallback { get; }
+    }
+
+    protected NodeBase(IPluginProvider pluginProvider, string hostName, ILogger? logger) {}
     protected NodeBase(IReadOnlyCollection<IPlugin> plugins, string hostName, ILogger? logger) {}
 
     public virtual Encoding Encoding { get; }
     public string HostName { get; }
+    protected ILogger? Logger { get; }
     public virtual Version NodeVersion { get; }
+    [Obsolete("This member will be deprecated in future version.")]
     public IReadOnlyCollection<IPlugin> Plugins { get; }
 
     public async ValueTask AcceptAsync(bool throwIfCancellationRequested, CancellationToken cancellationToken) {}
@@ -87,6 +99,11 @@ namespace Smdn.Net.MuninPlugin {
     string Name { get; }
 
     ValueTask<string> GetFormattedValueStringAsync(CancellationToken cancellationToken);
+  }
+
+  public interface IPluginProvider {
+    IReadOnlyCollection<IPlugin> Plugins { get; }
+    INodeSessionCallback? SessionCallback { get; }
   }
 
   public enum PluginFieldGraphStyle : int {
@@ -128,6 +145,7 @@ namespace Smdn.Net.MuninPlugin {
     public static IPluginField CreateField(string label, Func<double?> fetchValue) {}
     public static IPluginField CreateField(string label, PluginFieldGraphStyle graphStyle, Func<double?> fetchValue) {}
     public static IPluginField CreateField(string label, PluginFieldGraphStyle graphStyle, PluginFieldNormalValueRange normalRangeForWarning, PluginFieldNormalValueRange normalRangeForCritical, Func<double?> fetchValue) {}
+    public static IPluginField CreateField(string name, string label, PluginFieldGraphStyle graphStyle, PluginFieldNormalValueRange normalRangeForWarning, PluginFieldNormalValueRange normalRangeForCritical, Func<double?> fetchValue) {}
     public static IPlugin CreatePlugin(string name, PluginGraphAttributes graphAttributes, IReadOnlyCollection<IPluginField> fields) {}
     public static IPlugin CreatePlugin(string name, PluginGraphAttributes graphAttributes, IReadOnlyCollection<PluginFieldBase> fields) {}
     public static IPlugin CreatePlugin(string name, PluginGraphAttributes graphAttributes, PluginFieldBase field) {}
@@ -150,14 +168,18 @@ namespace Smdn.Net.MuninPlugin {
   }
 
   public sealed class PluginGraphAttributes {
+    [Obsolete("This member will be deprecated in future version.")]
     public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan updateRate, int? width = null, int? height = null) {}
+    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan? updateRate = null, int? width = null, int? height = null) {}
+    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan? updateRate, int? width, int? height, IEnumerable<string>? order) {}
 
     public string Arguments { get; }
     public string Category { get; }
     public int? Height { get; }
+    public string? Order { get; }
     public bool Scale { get; }
     public string Title { get; }
-    public TimeSpan UpdateRate { get; }
+    public TimeSpan? UpdateRate { get; }
     public string VerticalLabel { get; }
     public int? Width { get; }
   }

--- a/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-1.1.0)
+// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-1.2.0)
 //   Name: Smdn.Net.MuninNode
-//   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0+8c512e91195981258988a30fdf9c0ff4c53a6acc
+//   AssemblyVersion: 1.2.0.0
+//   InformationalVersion: 1.2.0+b0e11cd6b408018ad93f29b49e58cab7e9ef6b1b
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -26,6 +26,8 @@ using Smdn.Net.MuninPlugin;
 
 namespace Smdn.Net.MuninNode {
   public class LocalNode : NodeBase {
+    public LocalNode(IPluginProvider pluginProvider, string hostName, int port, ILogger? logger = null) {}
+    public LocalNode(IPluginProvider pluginProvider, string hostName, int port, IServiceProvider? serviceProvider = null) {}
     public LocalNode(IReadOnlyCollection<IPlugin> plugins, int port, IServiceProvider? serviceProvider = null) {}
     public LocalNode(IReadOnlyCollection<IPlugin> plugins, string hostName, int port, IServiceProvider? serviceProvider = null) {}
 
@@ -39,11 +41,21 @@ namespace Smdn.Net.MuninNode {
     IAsyncDisposable,
     IDisposable
   {
+    private protected class PluginProvider : IPluginProvider {
+      public PluginProvider(IReadOnlyCollection<IPlugin> plugins) {}
+
+      public IReadOnlyCollection<IPlugin> Plugins { get; }
+      public INodeSessionCallback? SessionCallback { get; }
+    }
+
+    protected NodeBase(IPluginProvider pluginProvider, string hostName, ILogger? logger) {}
     protected NodeBase(IReadOnlyCollection<IPlugin> plugins, string hostName, ILogger? logger) {}
 
     public virtual Encoding Encoding { get; }
     public string HostName { get; }
+    protected ILogger? Logger { get; }
     public virtual Version NodeVersion { get; }
+    [Obsolete("This member will be deprecated in future version.")]
     public IReadOnlyCollection<IPlugin> Plugins { get; }
 
     public async ValueTask AcceptAsync(bool throwIfCancellationRequested, CancellationToken cancellationToken) {}
@@ -80,6 +92,11 @@ namespace Smdn.Net.MuninPlugin {
     string Name { get; }
 
     ValueTask<string> GetFormattedValueStringAsync(CancellationToken cancellationToken);
+  }
+
+  public interface IPluginProvider {
+    IReadOnlyCollection<IPlugin> Plugins { get; }
+    INodeSessionCallback? SessionCallback { get; }
   }
 
   public enum PluginFieldGraphStyle : int {
@@ -121,6 +138,7 @@ namespace Smdn.Net.MuninPlugin {
     public static IPluginField CreateField(string label, Func<double?> fetchValue) {}
     public static IPluginField CreateField(string label, PluginFieldGraphStyle graphStyle, Func<double?> fetchValue) {}
     public static IPluginField CreateField(string label, PluginFieldGraphStyle graphStyle, PluginFieldNormalValueRange normalRangeForWarning, PluginFieldNormalValueRange normalRangeForCritical, Func<double?> fetchValue) {}
+    public static IPluginField CreateField(string name, string label, PluginFieldGraphStyle graphStyle, PluginFieldNormalValueRange normalRangeForWarning, PluginFieldNormalValueRange normalRangeForCritical, Func<double?> fetchValue) {}
     public static IPlugin CreatePlugin(string name, PluginGraphAttributes graphAttributes, IReadOnlyCollection<IPluginField> fields) {}
     public static IPlugin CreatePlugin(string name, PluginGraphAttributes graphAttributes, IReadOnlyCollection<PluginFieldBase> fields) {}
     public static IPlugin CreatePlugin(string name, PluginGraphAttributes graphAttributes, PluginFieldBase field) {}
@@ -143,14 +161,18 @@ namespace Smdn.Net.MuninPlugin {
   }
 
   public sealed class PluginGraphAttributes {
+    [Obsolete("This member will be deprecated in future version.")]
     public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan updateRate, int? width = null, int? height = null) {}
+    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan? updateRate = null, int? width = null, int? height = null) {}
+    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan? updateRate, int? width, int? height, IEnumerable<string>? order) {}
 
     public string Arguments { get; }
     public string Category { get; }
     public int? Height { get; }
+    public string? Order { get; }
     public bool Scale { get; }
     public string Title { get; }
-    public TimeSpan UpdateRate { get; }
+    public TimeSpan? UpdateRate { get; }
     public string VerticalLabel { get; }
     public int? Width { get; }
   }


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #6](https://github.com/smdn/Smdn.Net.MuninNode/actions/runs/5679643619).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.MuninNode-1.2.0`
- package_prevver_ref: `releases/Smdn.Net.MuninNode-1.1.0`
- package_prevver_tag: `releases/Smdn.Net.MuninNode-1.1.0`
- package_id: `Smdn.Net.MuninNode`
- package_id_with_version: `Smdn.Net.MuninNode-1.2.0`
- package_version: `1.2.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.MuninNode-1.2.0-1690455203`
- release_tag: `releases/Smdn.Net.MuninNode-1.2.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/28aae721e6336abb04c74d63359ccac8`](https://gist.github.com/smdn/28aae721e6336abb04c74d63359ccac8)
- artifact_name_nupkg: `Smdn.Net.MuninNode.1.2.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.MuninNode.latest.nuspec
+++ Smdn.Net.MuninNode.1.2.0.nuspec
@@ -1,34 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.MuninNode</id>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <title>Smdn.Net.MuninNode</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.MuninNode.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.MuninNode</projectUrl>
     <description>A .NET implementation of [Munin-Node](http://guide.munin-monitoring.org/en/latest/node/index.html) and [Munin-Plugin](http://guide.munin-monitoring.org/en/latest/plugin/index.html).  This library provides Munin-Node implementation for .NET, which enables to you to create custom Munin-Node using the .NET languages and libraries.  This library also provides abstraction APIs for implementing Munin-Plugin. By using Munin-Plugin APIs in combination with the Munin-Node implementation, you can implement the function of collecting various kind of telemetry data using Munin, with .NET.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.MuninNode/releases/tag/releases%2FSmdn.Net.MuninNode-1.1.0</releaseNotes>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.MuninNode/releases/tag/releases%2FSmdn.Net.MuninNode-1.2.0</releaseNotes>
     <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp Munin,Munin-Node,Munin-Plugin</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.MuninNode" branch="main" commit="8c512e91195981258988a30fdf9c0ff4c53a6acc" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.MuninNode" commit="b0e11cd6b408018ad93f29b49e58cab7e9ef6b1b" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Encoding.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net6.0/Smdn.Net.MuninNode.dll" target="lib/net6.0/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/netstandard2.1/Smdn.Net.MuninNode.dll" target="lib/netstandard2.1/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/.nuget/packages/smdn.msbuild.projectassets.common/1.3.6/project/images/package-icon.png" target="Smdn.Net.MuninNode.png" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

