### PR TITLE
Release main/Smdn.Net.MuninNode-2.0.0

### DIFF
--- a/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-1.3.0)
+// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-2.0.0)
 //   Name: Smdn.Net.MuninNode
-//   AssemblyVersion: 1.3.0.0
-//   InformationalVersion: 1.3.0+191d215fe57392cb544e2ffea221644a1007cfc0
+//   AssemblyVersion: 2.0.0.0
+//   InformationalVersion: 2.0.0+0c4121c0bc87932e6486c3b38a123cb59460ac02
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -27,43 +27,43 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Smdn.Net.MuninNode;
 using Smdn.Net.MuninPlugin;
 
 namespace Smdn.Net.MuninNode {
-  public class LocalNode : NodeBase {
-    public LocalNode(IPluginProvider pluginProvider, string hostName, int port, ILogger? logger = null) {}
-    public LocalNode(IPluginProvider pluginProvider, string hostName, int port, IServiceProvider? serviceProvider = null) {}
-    public LocalNode(IReadOnlyCollection<IPlugin> plugins, int port, IServiceProvider? serviceProvider = null) {}
-    public LocalNode(IReadOnlyCollection<IPlugin> plugins, string hostName, int port, IServiceProvider? serviceProvider = null) {}
+  public interface IAccessRule {
+    bool IsAcceptable(IPEndPoint remoteEndPoint);
+  }
 
-    public IPEndPoint LocalEndPoint { get; }
+  public static class IAccessRuleServiceCollectionExtensions {
+    public static IServiceCollection AddMuninNodeAccessRule(this IServiceCollection services, IAccessRule accessRule) {}
+    public static IServiceCollection AddMuninNodeAccessRule(this IServiceCollection services, IReadOnlyList<IPAddress> addressListAllowFrom) {}
+  }
+
+  public abstract class LocalNode : NodeBase {
+    public static LocalNode Create(IPluginProvider pluginProvider, int port, string? hostName = null, IReadOnlyList<IPAddress>? addressListAllowFrom = null, IServiceProvider? serviceProvider = null) {}
+    public static LocalNode Create(IReadOnlyCollection<IPlugin> plugins, int port, string? hostName = null, IReadOnlyList<IPAddress>? addressListAllowFrom = null, IServiceProvider? serviceProvider = null) {}
+
+    protected LocalNode(IAccessRule? accessRule, ILogger? logger = null) {}
 
     protected override Socket CreateServerSocket() {}
-    protected override bool IsClientAcceptable(IPEndPoint remoteEndPoint) {}
+    protected virtual EndPoint GetLocalEndPointToBind() {}
   }
 
   public abstract class NodeBase :
     IAsyncDisposable,
     IDisposable
   {
-    private protected class PluginProvider : IPluginProvider {
-      public PluginProvider(IReadOnlyCollection<IPlugin> plugins) {}
-
-      public IReadOnlyCollection<IPlugin> Plugins { get; }
-      public INodeSessionCallback? SessionCallback { get; }
-    }
-
-    protected NodeBase(IPluginProvider pluginProvider, string hostName, ILogger? logger) {}
-    protected NodeBase(IReadOnlyCollection<IPlugin> plugins, string hostName, ILogger? logger) {}
+    protected NodeBase(IAccessRule? accessRule, ILogger? logger) {}
 
     public virtual Encoding Encoding { get; }
-    public string HostName { get; }
+    public abstract string HostName { get; }
+    public EndPoint LocalEndPoint { get; }
     protected ILogger? Logger { get; }
     public virtual Version NodeVersion { get; }
-    [Obsolete("This member will be deprecated in future version.")]
-    public IReadOnlyCollection<IPlugin> Plugins { get; }
+    public abstract IPluginProvider PluginProvider { get; }
 
     public async ValueTask AcceptAsync(bool throwIfCancellationRequested, CancellationToken cancellationToken) {}
     public async ValueTask AcceptSingleSessionAsync(CancellationToken cancellationToken = default) {}
@@ -72,8 +72,8 @@ namespace Smdn.Net.MuninNode {
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
     protected virtual async ValueTask DisposeAsyncCore() {}
-    protected abstract bool IsClientAcceptable(IPEndPoint remoteEndPoint);
     public void Start() {}
+    protected void ThrowIfPluginProviderIsNull() {}
   }
 }
 
@@ -85,7 +85,7 @@ namespace Smdn.Net.MuninPlugin {
 
   public interface IPlugin {
     IPluginDataSource DataSource { get; }
-    PluginGraphAttributes GraphAttributes { get; }
+    IPluginGraphAttributes GraphAttributes { get; }
     string Name { get; }
     INodeSessionCallback? SessionCallback { get; }
   }
@@ -99,6 +99,10 @@ namespace Smdn.Net.MuninPlugin {
     string Name { get; }
 
     ValueTask<string> GetFormattedValueStringAsync(CancellationToken cancellationToken);
+  }
+
+  public interface IPluginGraphAttributes {
+    IEnumerable<string> EnumerateAttributes();
   }
 
   public interface IPluginProvider {
@@ -132,6 +136,7 @@ namespace Smdn.Net.MuninPlugin {
     public PluginGraphAttributes GraphAttributes { get; }
     public string Name { get; }
     IPluginDataSource IPlugin.DataSource { get; }
+    IPluginGraphAttributes IPlugin.GraphAttributes { get; }
     INodeSessionCallback? IPlugin.SessionCallback { get; }
     IReadOnlyCollection<IPluginField> IPluginDataSource.Fields { get; }
 
@@ -170,11 +175,9 @@ namespace Smdn.Net.MuninPlugin {
     async ValueTask<string> IPluginField.GetFormattedValueStringAsync(CancellationToken cancellationToken) {}
   }
 
-  public sealed class PluginGraphAttributes {
-    [Obsolete("This member will be deprecated in future version.")]
-    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan updateRate, int? width = null, int? height = null) {}
-    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan? updateRate = null, int? width = null, int? height = null) {}
-    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan? updateRate, int? width, int? height, IEnumerable<string>? order) {}
+  public sealed class PluginGraphAttributes : IPluginGraphAttributes {
+    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments) {}
+    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan? updateRate, int? width, int? height, IEnumerable<string>? order, string? totalValueLabel) {}
 
     public string Arguments { get; }
     public string Category { get; }
@@ -182,9 +185,12 @@ namespace Smdn.Net.MuninPlugin {
     public string? Order { get; }
     public bool Scale { get; }
     public string Title { get; }
+    public string? TotalValueLabel { get; }
     public TimeSpan? UpdateRate { get; }
     public string VerticalLabel { get; }
     public int? Width { get; }
+
+    public IEnumerable<string> EnumerateAttributes() {}
   }
 
   public readonly struct PluginFieldAttributes {

--- a/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-1.3.0)
+// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-2.0.0)
 //   Name: Smdn.Net.MuninNode
-//   AssemblyVersion: 1.3.0.0
-//   InformationalVersion: 1.3.0+191d215fe57392cb544e2ffea221644a1007cfc0
+//   AssemblyVersion: 2.0.0.0
+//   InformationalVersion: 2.0.0+0c4121c0bc87932e6486c3b38a123cb59460ac02
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -20,43 +20,43 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Smdn.Net.MuninNode;
 using Smdn.Net.MuninPlugin;
 
 namespace Smdn.Net.MuninNode {
-  public class LocalNode : NodeBase {
-    public LocalNode(IPluginProvider pluginProvider, string hostName, int port, ILogger? logger = null) {}
-    public LocalNode(IPluginProvider pluginProvider, string hostName, int port, IServiceProvider? serviceProvider = null) {}
-    public LocalNode(IReadOnlyCollection<IPlugin> plugins, int port, IServiceProvider? serviceProvider = null) {}
-    public LocalNode(IReadOnlyCollection<IPlugin> plugins, string hostName, int port, IServiceProvider? serviceProvider = null) {}
+  public interface IAccessRule {
+    bool IsAcceptable(IPEndPoint remoteEndPoint);
+  }
 
-    public IPEndPoint LocalEndPoint { get; }
+  public static class IAccessRuleServiceCollectionExtensions {
+    public static IServiceCollection AddMuninNodeAccessRule(this IServiceCollection services, IAccessRule accessRule) {}
+    public static IServiceCollection AddMuninNodeAccessRule(this IServiceCollection services, IReadOnlyList<IPAddress> addressListAllowFrom) {}
+  }
+
+  public abstract class LocalNode : NodeBase {
+    public static LocalNode Create(IPluginProvider pluginProvider, int port, string? hostName = null, IReadOnlyList<IPAddress>? addressListAllowFrom = null, IServiceProvider? serviceProvider = null) {}
+    public static LocalNode Create(IReadOnlyCollection<IPlugin> plugins, int port, string? hostName = null, IReadOnlyList<IPAddress>? addressListAllowFrom = null, IServiceProvider? serviceProvider = null) {}
+
+    protected LocalNode(IAccessRule? accessRule, ILogger? logger = null) {}
 
     protected override Socket CreateServerSocket() {}
-    protected override bool IsClientAcceptable(IPEndPoint remoteEndPoint) {}
+    protected virtual EndPoint GetLocalEndPointToBind() {}
   }
 
   public abstract class NodeBase :
     IAsyncDisposable,
     IDisposable
   {
-    private protected class PluginProvider : IPluginProvider {
-      public PluginProvider(IReadOnlyCollection<IPlugin> plugins) {}
-
-      public IReadOnlyCollection<IPlugin> Plugins { get; }
-      public INodeSessionCallback? SessionCallback { get; }
-    }
-
-    protected NodeBase(IPluginProvider pluginProvider, string hostName, ILogger? logger) {}
-    protected NodeBase(IReadOnlyCollection<IPlugin> plugins, string hostName, ILogger? logger) {}
+    protected NodeBase(IAccessRule? accessRule, ILogger? logger) {}
 
     public virtual Encoding Encoding { get; }
-    public string HostName { get; }
+    public abstract string HostName { get; }
+    public EndPoint LocalEndPoint { get; }
     protected ILogger? Logger { get; }
     public virtual Version NodeVersion { get; }
-    [Obsolete("This member will be deprecated in future version.")]
-    public IReadOnlyCollection<IPlugin> Plugins { get; }
+    public abstract IPluginProvider PluginProvider { get; }
 
     public async ValueTask AcceptAsync(bool throwIfCancellationRequested, CancellationToken cancellationToken) {}
     public async ValueTask AcceptSingleSessionAsync(CancellationToken cancellationToken = default) {}
@@ -65,8 +65,8 @@ namespace Smdn.Net.MuninNode {
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
     protected virtual ValueTask DisposeAsyncCore() {}
-    protected abstract bool IsClientAcceptable(IPEndPoint remoteEndPoint);
     public void Start() {}
+    protected void ThrowIfPluginProviderIsNull() {}
   }
 }
 
@@ -78,7 +78,7 @@ namespace Smdn.Net.MuninPlugin {
 
   public interface IPlugin {
     IPluginDataSource DataSource { get; }
-    PluginGraphAttributes GraphAttributes { get; }
+    IPluginGraphAttributes GraphAttributes { get; }
     string Name { get; }
     INodeSessionCallback? SessionCallback { get; }
   }
@@ -92,6 +92,10 @@ namespace Smdn.Net.MuninPlugin {
     string Name { get; }
 
     ValueTask<string> GetFormattedValueStringAsync(CancellationToken cancellationToken);
+  }
+
+  public interface IPluginGraphAttributes {
+    IEnumerable<string> EnumerateAttributes();
   }
 
   public interface IPluginProvider {
@@ -125,6 +129,7 @@ namespace Smdn.Net.MuninPlugin {
     public PluginGraphAttributes GraphAttributes { get; }
     public string Name { get; }
     IPluginDataSource IPlugin.DataSource { get; }
+    IPluginGraphAttributes IPlugin.GraphAttributes { get; }
     INodeSessionCallback? IPlugin.SessionCallback { get; }
     IReadOnlyCollection<IPluginField> IPluginDataSource.Fields { get; }
 
@@ -163,11 +168,9 @@ namespace Smdn.Net.MuninPlugin {
     async ValueTask<string> IPluginField.GetFormattedValueStringAsync(CancellationToken cancellationToken) {}
   }
 
-  public sealed class PluginGraphAttributes {
-    [Obsolete("This member will be deprecated in future version.")]
-    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan updateRate, int? width = null, int? height = null) {}
-    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan? updateRate = null, int? width = null, int? height = null) {}
-    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan? updateRate, int? width, int? height, IEnumerable<string>? order) {}
+  public sealed class PluginGraphAttributes : IPluginGraphAttributes {
+    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments) {}
+    public PluginGraphAttributes(string title, string category, string verticalLabel, bool scale, string arguments, TimeSpan? updateRate, int? width, int? height, IEnumerable<string>? order, string? totalValueLabel) {}
 
     public string Arguments { get; }
     public string Category { get; }
@@ -175,9 +178,12 @@ namespace Smdn.Net.MuninPlugin {
     public string? Order { get; }
     public bool Scale { get; }
     public string Title { get; }
+    public string? TotalValueLabel { get; }
     public TimeSpan? UpdateRate { get; }
     public string VerticalLabel { get; }
     public int? Width { get; }
+
+    public IEnumerable<string> EnumerateAttributes() {}
   }
 
   public readonly struct PluginFieldAttributes {


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #8](https://github.com/smdn/Smdn.Net.MuninNode/actions/runs/11651970579).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.MuninNode-2.0.0`
- package_prevver_ref: `releases/Smdn.Net.MuninNode-1.3.0`
- package_prevver_tag: `releases/Smdn.Net.MuninNode-1.3.0`
- package_id: `Smdn.Net.MuninNode`
- package_id_with_version: `Smdn.Net.MuninNode-2.0.0`
- package_version: `2.0.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.MuninNode-2.0.0-1730642601`
- release_tag: `releases/Smdn.Net.MuninNode-2.0.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/be7de05385a95a110057cef21b75ff32`](https://gist.github.com/smdn/be7de05385a95a110057cef21b75ff32)
- artifact_name_nupkg: `Smdn.Net.MuninNode.2.0.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.MuninNode.latest.nuspec
+++ Smdn.Net.MuninNode.2.0.0.nuspec
@@ -1,40 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.MuninNode</id>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
     <title>Smdn.Net.MuninNode</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.MuninNode.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.MuninNode</projectUrl>
     <description>A .NET implementation of [Munin-Node](https://guide.munin-monitoring.org/en/latest/node/index.html) and [Munin-Plugin](https://guide.munin-monitoring.org/en/latest/plugin/index.html).  This library provides Munin-Node implementation for .NET, which enables to you to create custom Munin-Node using the .NET languages and libraries.  This library also provides abstraction APIs for implementing Munin-Plugin. By using Munin-Plugin APIs in combination with the Munin-Node implementation, you can implement the function of collecting various kind of telemetry data using Munin, with .NET.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.MuninNode/releases/tag/releases%2FSmdn.Net.MuninNode-1.3.0</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.MuninNode/releases/tag/releases%2FSmdn.Net.MuninNode-2.0.0</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp Munin,Munin-Node,Munin-Plugin</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.MuninNode" branch="main" commit="191d215fe57392cb544e2ffea221644a1007cfc0" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.MuninNode" commit="0c4121c0bc87932e6486c3b38a123cb59460ac02" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Encoding.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net6.0/Smdn.Net.MuninNode.dll" target="lib/net6.0/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net6.0/Smdn.Net.MuninNode.xml" target="lib/net6.0/Smdn.Net.MuninNode.xml" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net8.0/Smdn.Net.MuninNode.dll" target="lib/net8.0/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net8.0/Smdn.Net.MuninNode.xml" target="lib/net8.0/Smdn.Net.MuninNode.xml" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/netstandard2.1/Smdn.Net.MuninNode.dll" target="lib/netstandard2.1/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/netstandard2.1/Smdn.Net.MuninNode.xml" target="lib/netstandard2.1/Smdn.Net.MuninNode.xml" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Net.MuninNode.png" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

