### PR TITLE
Fix formatting decimal point values to be culture invariant

### DIFF
--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/PluginFieldBase.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/PluginFieldBase.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -86,7 +87,7 @@ public abstract class PluginFieldBase : IPluginField {
 
     var value = await FetchValueAsync(cancellationToken).ConfigureAwait(false);
 
-    return value?.ToString(provider: null) ?? UnknownValueString; // TODO: format specifier
+    return value?.ToString(provider: CultureInfo.InvariantCulture) ?? UnknownValueString;
   }
 #pragma warning restore CA1033
 

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
@@ -638,7 +638,42 @@ public class NodeBaseTests {
   }
 
   [TestCaseSource(nameof(YieldTestCases_ProcessCommandAsync_FetchCommand))]
-  public Task ProcessCommandAsync_FetchCommand(
+  [SetCulture("")]
+  public Task ProcessCommandAsync_FetchCommand_InvariantCulture(
+    IReadOnlyList<IPlugin> plugins,
+    string command,
+    string[] expectedResponseLines
+  )
+    => ProcessCommandAsync_FetchCommand(plugins, command, expectedResponseLines);
+
+  [TestCaseSource(nameof(YieldTestCases_ProcessCommandAsync_FetchCommand))]
+  [SetCulture("ja_JP")]
+  public Task ProcessCommandAsync_FetchCommand_JA_JP(
+    IReadOnlyList<IPlugin> plugins,
+    string command,
+    string[] expectedResponseLines
+  )
+    => ProcessCommandAsync_FetchCommand(plugins, command, expectedResponseLines);
+
+  [TestCaseSource(nameof(YieldTestCases_ProcessCommandAsync_FetchCommand))]
+  [SetCulture("fr_CH")]
+  public Task ProcessCommandAsync_FetchCommand_FR_CH(
+    IReadOnlyList<IPlugin> plugins,
+    string command,
+    string[] expectedResponseLines
+  )
+    => ProcessCommandAsync_FetchCommand(plugins, command, expectedResponseLines);
+
+  [TestCaseSource(nameof(YieldTestCases_ProcessCommandAsync_FetchCommand))]
+  [SetCulture("ar_AA")]
+  public Task ProcessCommandAsync_FetchCommand_AR_AA(
+    IReadOnlyList<IPlugin> plugins,
+    string command,
+    string[] expectedResponseLines
+  )
+    => ProcessCommandAsync_FetchCommand(plugins, command, expectedResponseLines);
+
+  private Task ProcessCommandAsync_FetchCommand(
     IReadOnlyList<IPlugin> plugins,
     string command,
     string[] expectedResponseLines

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
@@ -665,8 +665,8 @@ public class NodeBaseTests {
     => ProcessCommandAsync_FetchCommand(plugins, command, expectedResponseLines);
 
   [TestCaseSource(nameof(YieldTestCases_ProcessCommandAsync_FetchCommand))]
-  [SetCulture("ar_AA")]
-  public Task ProcessCommandAsync_FetchCommand_AR_AA(
+  [SetCulture("ar_AE")]
+  public Task ProcessCommandAsync_FetchCommand_AR_AE(
     IReadOnlyList<IPlugin> plugins,
     string command,
     string[] expectedResponseLines

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/PluginFieldBase.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/PluginFieldBase.cs
@@ -93,4 +93,50 @@ public class PluginFieldBaseTests {
   [TestCase("LABEL#")]
   public void DefaultNameFromLabel_Invalid(string label)
     => Assert.Throws<ArgumentException>(() => new ConcretePluginField(label: label));
+
+  private class FloatingPointValuePluginField : PluginFieldBase {
+    private readonly double value;
+
+    public FloatingPointValuePluginField(double value)
+      : base(label: "label", name: "name")
+    {
+      this.value = value;
+    }
+
+    protected override ValueTask<double?> FetchValueAsync(CancellationToken cancellationToken)
+      => new(value);
+  }
+
+  [Test]
+  [SetCulture("")]
+  public Task IPluginField_GetFormattedValueStringAsync_DecimalPoint_InvariantCulture()
+    => IPluginField_GetFormattedValueStringAsync_DecimalPoint();
+
+  [Test]
+  [SetCulture("ja_JP")]
+  public Task IPluginField_GetFormattedValueStringAsync_DecimalPoint_JA_JP()
+    => IPluginField_GetFormattedValueStringAsync_DecimalPoint();
+
+  [Test]
+  [SetCulture("fr_CH")]
+  public Task IPluginField_GetFormattedValueStringAsync_DecimalPoint_FR_CH()
+    => IPluginField_GetFormattedValueStringAsync_DecimalPoint();
+
+  [Test]
+  [SetCulture("ar_AA")]
+  public Task IPluginField_GetFormattedValueStringAsync_DecimalPoint_AR_AA()
+    => IPluginField_GetFormattedValueStringAsync_DecimalPoint();
+
+  private async Task IPluginField_GetFormattedValueStringAsync_DecimalPoint()
+  {
+    const double RawFieldValue = 0.25;
+    const string ExpectedFormattedValueString = "0.25";
+
+    var f = new FloatingPointValuePluginField(RawFieldValue);
+
+    Assert.That(
+      await ((IPluginField)f).GetFormattedValueStringAsync(default).ConfigureAwait(false),
+      Is.EqualTo(ExpectedFormattedValueString)
+    );
+  }
 }

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/PluginFieldBase.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/PluginFieldBase.cs
@@ -123,8 +123,8 @@ public class PluginFieldBaseTests {
     => IPluginField_GetFormattedValueStringAsync_DecimalPoint();
 
   [Test]
-  [SetCulture("ar_AA")]
-  public Task IPluginField_GetFormattedValueStringAsync_DecimalPoint_AR_AA()
+  [SetCulture("ar_AE")]
+  public Task IPluginField_GetFormattedValueStringAsync_DecimalPoint_AR_AE()
     => IPluginField_GetFormattedValueStringAsync_DecimalPoint();
 
   private async Task IPluginField_GetFormattedValueStringAsync_DecimalPoint()


### PR DESCRIPTION
### Description
The string conversion in `PluginFieldBase.GetFormattedValueStringAsync` is culture dependent in the execution environment.
This means that the decimal point symbol of the field value is output differently in different cultures.

In order to always use the period `.` as the decimal symbol, this PR changes the formatting to use `CultureInfo.InvariantCulture`.

This problem was noted and discovered in #12.
