### PR TITLE
Add APIs to support dependency injection

### DIFF
--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/DefaultMuninNode.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/DefaultMuninNode.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Net;
+
+using Microsoft.Extensions.Logging;
+
+using Smdn.Net.MuninNode.AccessRules;
+using Smdn.Net.MuninNode.Transport;
+using Smdn.Net.MuninPlugin;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+/// <summary>
+/// Implement a <c>Munin-Node</c> that can be configured by IServiceProvider or other interfaces.
+/// </summary>
+internal sealed class DefaultMuninNode : NodeBase, IMuninNode {
+  private readonly MuninNodeOptions options;
+
+  public override string HostName => options.HostName;
+  public override IPluginProvider PluginProvider { get; }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="DefaultMuninNode"/> class.
+  /// </summary>
+  /// <param name="options">
+  /// The <see cref="MuninNodeOptions"/> to configure the <c>Munin-Node</c>.
+  /// </param>
+  /// <param name="pluginProvider">
+  /// The <see cref="IPluginProvider"/> to provide <c>Munin plugins</c> for this instance.
+  /// </param>
+  /// <param name="listenerFactory">
+  /// The <see cref="IMuninNodeListenerFactory"/> to create a listener for this instance.
+  /// If <see langword="null"/>, the default factory will be used.
+  /// </param>
+  /// <param name="logger">
+  /// The <see cref="ILogger"/> to report the situation.
+  /// </param>
+  /// <remarks>
+  /// If <see cref="MuninNodeOptions.AccessRule"/> is <see langword="null"/>, only allow access from the loopback address.
+  /// </remarks>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="options"/> is <see langword="null"/>, or
+  /// <paramref name="pluginProvider"/> is <see langword="null"/>.
+  /// </exception>
+  public DefaultMuninNode(
+    MuninNodeOptions options,
+    IPluginProvider pluginProvider,
+    IMuninNodeListenerFactory? listenerFactory,
+    ILogger? logger
+  )
+    : base(
+      listenerFactory: listenerFactory ?? MuninNodeListenerFactory.Instance,
+      accessRule: (options ?? throw new ArgumentNullException(nameof(options))).AccessRule ?? LoopbackOnlyAccessRule.Instance,
+      logger: logger
+    )
+  {
+    this.options = options;
+    PluginProvider = pluginProvider ?? throw new ArgumentNullException(nameof(pluginProvider));
+  }
+
+  protected override EndPoint GetLocalEndPointToBind()
+    => new IPEndPoint(options.Address, options.Port);
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/DefaultMuninNodeBuilder.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/DefaultMuninNodeBuilder.cs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Smdn.Net.MuninNode.Transport;
+using Smdn.Net.MuninPlugin;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+internal sealed class DefaultMuninNodeBuilder : IMuninNodeBuilder {
+  private readonly List<Func<IServiceProvider, IPlugin>> pluginFactories = new(capacity: 4);
+  private Func<IServiceProvider, IPluginProvider>? buildPluginProvider;
+  private Func<IServiceProvider, INodeSessionCallback>? buildSessionCallback;
+  private Func<IServiceProvider, IMuninNodeListenerFactory>? buildListenerFactory;
+
+  public IServiceCollection Services { get; }
+  public string ServiceKey { get; }
+
+  public DefaultMuninNodeBuilder(IMuninServiceBuilder serviceBuilder, string serviceKey)
+  {
+    Services = (serviceBuilder ?? throw new ArgumentNullException(nameof(serviceBuilder))).Services;
+    ServiceKey = serviceKey ?? throw new ArgumentNullException(nameof(serviceKey));
+  }
+
+  public void AddPluginFactory(Func<IServiceProvider, IPlugin> buildPlugin)
+  {
+    if (buildPlugin is null)
+      throw new ArgumentNullException(nameof(buildPlugin));
+
+    pluginFactories.Add(serviceProvider => buildPlugin(serviceProvider));
+  }
+
+  public void SetPluginProviderFactory(
+    Func<IServiceProvider, IPluginProvider> buildPluginProvider
+  )
+  {
+    if (buildPluginProvider is null)
+      throw new ArgumentNullException(nameof(buildPluginProvider));
+
+    this.buildPluginProvider = buildPluginProvider;
+  }
+
+  public void SetSessionCallbackFactory(
+    Func<IServiceProvider, INodeSessionCallback> buildSessionCallback
+  )
+  {
+    if (buildSessionCallback is null)
+      throw new ArgumentNullException(nameof(buildSessionCallback));
+
+    this.buildSessionCallback = buildSessionCallback;
+  }
+
+  public void SetListenerFactory(
+    Func<IServiceProvider, IMuninNodeListenerFactory> buildListenerFactory
+  )
+  {
+    if (buildListenerFactory is null)
+      throw new ArgumentNullException(nameof(buildListenerFactory));
+
+    this.buildListenerFactory = buildListenerFactory;
+  }
+
+  public IMuninNode Build(IServiceProvider serviceProvider)
+  {
+    if (serviceProvider is null)
+      throw new ArgumentNullException(nameof(serviceProvider));
+
+    return new DefaultMuninNode(
+      options: serviceProvider.GetRequiredService<IOptionsMonitor<MuninNodeOptions>>().Get(name: ServiceKey),
+      pluginProvider: buildPluginProvider is null
+        ? new PluginProvider(
+            plugins: pluginFactories.Select(factory => factory(serviceProvider)).ToList(),
+            sessionCallback: buildSessionCallback?.Invoke(serviceProvider)
+          )
+        : buildPluginProvider.Invoke(serviceProvider),
+      listenerFactory: buildListenerFactory?.Invoke(serviceProvider),
+      logger: serviceProvider.GetService<ILoggerFactory>()?.CreateLogger<DefaultMuninNode>()
+    );
+  }
+
+  private sealed class PluginProvider : IPluginProvider {
+    public IReadOnlyCollection<IPlugin> Plugins { get; }
+    public INodeSessionCallback? SessionCallback { get; }
+
+    public PluginProvider(
+      IReadOnlyCollection<IPlugin> plugins,
+      INodeSessionCallback? sessionCallback
+    )
+    {
+      Plugins = plugins ?? throw new ArgumentNullException(nameof(plugins));
+      SessionCallback = sessionCallback;
+    }
+  }
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilder.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilder.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+#pragma warning disable CS0419
+
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+/// <summary>
+/// An interface for configuring the <c>Munin-Node</c> service providers.
+/// </summary>
+/// <see cref="IMuninNodeBuilderExtensions.AddPlugin"/>
+/// <see cref="IMuninNodeBuilderExtensions.UseListenerFactory"/>
+/// <see cref="IMuninNodeBuilderExtensions.UseSessionCallback"/>
+public interface IMuninNodeBuilder {
+  /// <summary>
+  /// Gets the <see cref="IServiceCollection"/> where the <c>Munin-Node</c> services are configured.
+  /// </summary>
+  IServiceCollection Services { get; }
+
+  /// <summary>
+  /// Gets the <see cref="string"/> key of <c>Munin-Node</c> service.
+  /// </summary>
+  /// <remarks>
+  /// The value set as the hostname of the <c>Munin-Node</c> (see <see cref="MuninNodeOptions.HostName"/>) is used as the service key.
+  /// </remarks>
+  /// <see cref="IMuninServiceBuilderExtensions.AddNode(IMuninServiceBuilder, Action{MuninNodeOptions})"/>
+  string ServiceKey { get; }
+
+  /// <summary>
+  /// Builds the <c>Munin-Node</c> with current configurations.
+  /// </summary>
+  /// <param name="serviceProvider">
+  /// An <see cref="IServiceProvider"/> that provides the services to be used by the <see cref="IMuninNode"/> being built.
+  /// </param>
+  /// <returns>An initialized <see cref="IMuninNode"/>.</returns>
+  IMuninNode Build(IServiceProvider serviceProvider);
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Smdn.Net.MuninNode.Transport;
+using Smdn.Net.MuninPlugin;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+public static class IMuninNodeBuilderExtensions {
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static IMuninNodeBuilder AddPlugin(
+    this IMuninNodeBuilder builder,
+    IPlugin plugin
+  )
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (plugin is null)
+      throw new ArgumentNullException(nameof(plugin));
+
+    return AddPlugin(
+      builder: builder,
+      buildPlugin: _ => plugin
+    );
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static IMuninNodeBuilder AddPlugin(
+    this IMuninNodeBuilder builder,
+    Func<IServiceProvider, IPlugin> buildPlugin
+  )
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (buildPlugin is null)
+      throw new ArgumentNullException(nameof(buildPlugin));
+
+    if (builder is not DefaultMuninNodeBuilder defaultMuninNodeBuilder)
+      throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
+
+    defaultMuninNodeBuilder.AddPluginFactory(buildPlugin);
+
+    return builder;
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// Calling this method will override the configurations made by
+  /// <see cref="AddPlugin"/> and <see cref="UseSessionCallback"/>.
+  /// </remarks>
+  public static IMuninNodeBuilder UsePluginProvider(
+    this IMuninNodeBuilder builder,
+    IPluginProvider pluginProvider
+  )
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (pluginProvider is null)
+      throw new ArgumentNullException(nameof(pluginProvider));
+
+    return UsePluginProvider(
+      builder: builder,
+      buildPluginProvider: _ => pluginProvider
+    );
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// Calling this method will override the configurations made by
+  /// <see cref="AddPlugin"/> and <see cref="UseSessionCallback"/>.
+  /// </remarks>
+  public static IMuninNodeBuilder UsePluginProvider(
+    this IMuninNodeBuilder builder,
+    Func<IServiceProvider, IPluginProvider> buildPluginProvider
+  )
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (buildPluginProvider is null)
+      throw new ArgumentNullException(nameof(buildPluginProvider));
+
+    if (builder is not DefaultMuninNodeBuilder defaultMuninNodeBuilder)
+      throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
+
+    defaultMuninNodeBuilder.SetPluginProviderFactory(buildPluginProvider);
+
+    return builder;
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static IMuninNodeBuilder UseSessionCallback(
+    this IMuninNodeBuilder builder,
+    INodeSessionCallback sessionCallback
+  )
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (sessionCallback is null)
+      throw new ArgumentNullException(nameof(sessionCallback));
+
+    return UseSessionCallback(
+      builder: builder,
+      buildSessionCallback: _ => sessionCallback
+    );
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static IMuninNodeBuilder UseSessionCallback(
+    this IMuninNodeBuilder builder,
+    Func<string, CancellationToken, ValueTask>? reportSessionStartedAsyncFunc,
+    Func<string, CancellationToken, ValueTask>? reportSessionClosedAsyncFunc
+  )
+#pragma warning restore CS0419
+    => UseSessionCallback(
+      builder: builder,
+      buildSessionCallback: _ => new SessionCallbackFuncWrapper(
+        reportSessionStartedAsyncFunc,
+        reportSessionClosedAsyncFunc
+      )
+    );
+
+  private sealed class SessionCallbackFuncWrapper(
+    Func<string, CancellationToken, ValueTask>? reportSessionStartedAsyncFunc,
+    Func<string, CancellationToken, ValueTask>? reportSessionClosedAsyncFunc
+  ) : INodeSessionCallback {
+    public ValueTask ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken)
+      => reportSessionStartedAsyncFunc is null
+        ? default
+        : reportSessionStartedAsyncFunc(sessionId, cancellationToken);
+
+    public ValueTask ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken)
+      => reportSessionClosedAsyncFunc is null
+        ? default
+        : reportSessionClosedAsyncFunc(sessionId, cancellationToken);
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static IMuninNodeBuilder UseSessionCallback(
+    this IMuninNodeBuilder builder,
+    Func<IServiceProvider, INodeSessionCallback> buildSessionCallback
+  )
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (buildSessionCallback is null)
+      throw new ArgumentNullException(nameof(buildSessionCallback));
+
+    if (builder is not DefaultMuninNodeBuilder defaultMuninNodeBuilder)
+      throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
+
+    defaultMuninNodeBuilder.SetSessionCallbackFactory(buildSessionCallback);
+
+    return builder;
+  }
+
+  public static IMuninNodeBuilder UseListenerFactory(
+    this IMuninNodeBuilder builder,
+    IMuninNodeListenerFactory listenerFactory
+  )
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (listenerFactory is null)
+      throw new ArgumentNullException(nameof(listenerFactory));
+
+    return UseListenerFactory(
+      builder: builder,
+      buildListenerFactory: _ => listenerFactory
+    );
+  }
+
+  public static IMuninNodeBuilder UseListenerFactory(
+    this IMuninNodeBuilder builder,
+    Func<IServiceProvider, EndPoint, IMuninNode, CancellationToken, ValueTask<IMuninNodeListener>> createListenerAsyncFunc
+  )
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (createListenerAsyncFunc is null)
+      throw new ArgumentNullException(nameof(createListenerAsyncFunc));
+
+    return UseListenerFactory(
+      builder: builder,
+      buildListenerFactory: serviceProvider => new CreateListenerAsyncFuncWrapper(
+        serviceProvider,
+        createListenerAsyncFunc
+      )
+    );
+  }
+
+  private sealed class CreateListenerAsyncFuncWrapper(
+    IServiceProvider serviceProvider,
+    Func<IServiceProvider, EndPoint, IMuninNode, CancellationToken, ValueTask<IMuninNodeListener>> createListenerAsyncFunc
+  ) : IMuninNodeListenerFactory {
+    public ValueTask<IMuninNodeListener> CreateAsync(EndPoint endPoint, IMuninNode node, CancellationToken cancellationToken)
+      => createListenerAsyncFunc(serviceProvider, endPoint, node, cancellationToken);
+  }
+
+  public static IMuninNodeBuilder UseListenerFactory(
+    this IMuninNodeBuilder builder,
+    Func<IServiceProvider, IMuninNodeListenerFactory> buildListenerFactory
+  )
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (buildListenerFactory is null)
+      throw new ArgumentNullException(nameof(buildListenerFactory));
+
+    if (builder is not DefaultMuninNodeBuilder defaultMuninNodeBuilder)
+      throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
+
+    defaultMuninNodeBuilder.SetListenerFactory(buildListenerFactory);
+
+    return builder;
+  }
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilder.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilder.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+#pragma warning disable CS0419
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+/// <summary>
+/// An interface for configuring the Munin service providers.
+/// </summary>
+/// <see cref="IMuninServiceBuilderExtensions.AddNode"/>
+public interface IMuninServiceBuilder {
+  /// <summary>
+  /// Gets the <see cref="IServiceCollection"/> where the Munin services are configured.
+  /// </summary>
+  IServiceCollection Services { get; }
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+public static class IMuninServiceBuilderExtensions {
+  /// <summary>
+  /// Adds a <c>Munin-Node</c> to the <see cref="IMuninServiceBuilder"/> with default configurations.
+  /// </summary>
+  /// <param name="builder">An <see cref="IMuninNodeBuilder"/> to build the <c>Munin-Node</c> to be added.</param>
+  /// <returns>The current <see cref="IMuninNodeBuilder"/> so that additional calls can be chained.</returns>
+  public static IMuninNodeBuilder AddNode(
+    this IMuninServiceBuilder builder
+  )
+    => AddNode(
+      builder: builder,
+      configure: _ => { }
+    );
+
+  /// <summary>
+  /// Adds a <c>Munin-Node</c> to the <see cref="IMuninServiceBuilder"/> with specified configurations.
+  /// </summary>
+  /// <param name="builder">
+  /// An <see cref="IMuninNodeBuilder"/> to build the <c>Munin-Node</c> to be added.
+  /// </param>
+  /// <param name="configure">
+  /// An <see cref="Action{MuninNodeOptions}"/> to setup <see cref="MuninNodeOptions"/> to
+  /// configure the <c>Munin-Node</c> to be built.
+  /// </param>
+  /// <returns>The current <see cref="IMuninNodeBuilder"/> so that additional calls can be chained.</returns>
+  public static IMuninNodeBuilder AddNode(
+    this IMuninServiceBuilder builder,
+    Action<MuninNodeOptions> configure
+  )
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (configure is null)
+      throw new ArgumentNullException(nameof(configure));
+
+    var options = new MuninNodeOptions();
+
+    configure(options);
+
+    var nodeBuilder = new DefaultMuninNodeBuilder(
+      serviceBuilder: builder,
+      serviceKey: options.HostName // use configured hostname as a service key and option name
+    );
+
+    _ = builder.Services.Configure<MuninNodeOptions>(
+      name: nodeBuilder.ServiceKey, // configure MuninNodeOptions for this builder
+      opts => {
+        opts.Address = options.Address;
+        opts.Port = options.Port;
+        opts.HostName = options.HostName;
+        opts.AccessRule = options.AccessRule;
+      }
+    );
+
+    builder.Services.Add(
+      ServiceDescriptor.KeyedSingleton<IMuninNodeBuilder>(
+        serviceKey: nodeBuilder.ServiceKey,
+        implementationFactory: (_, _) => nodeBuilder
+      )
+    );
+
+    // add keyed/singleton IMuninNode
+    builder.Services.Add(
+      ServiceDescriptor.KeyedSingleton<IMuninNode>(
+        serviceKey: nodeBuilder.ServiceKey,
+        static (serviceProvider, serviceKey)
+            => serviceProvider.GetRequiredKeyedService<IMuninNodeBuilder>(serviceKey).Build(serviceProvider)
+      )
+    );
+
+    // add keyless/multiple IMuninNode
+    builder.Services.Add(
+      ServiceDescriptor.Transient<IMuninNode>(
+        nodeBuilder.Build
+      )
+    );
+
+    return nodeBuilder;
+  }
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+public static class IServiceCollectionExtensions {
+  /// <summary>
+  /// Adds an <see cref="IMuninServiceBuilder"/> to the <see cref="IServiceCollection"/>.
+  /// </summary>
+  /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+  /// <param name="configure">
+  /// An <see cref="Action{IMuninServiceBuilder}"/> to add munin services to the <see cref="IMuninServiceBuilder"/>.
+  /// </param>
+  /// <returns>The current <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+  public static IServiceCollection AddMunin(
+    this IServiceCollection services,
+    Action<IMuninServiceBuilder> configure
+  )
+  {
+    if (services is null)
+      throw new ArgumentNullException(nameof(services));
+    if (configure is null)
+      throw new ArgumentNullException(nameof(configure));
+
+    configure(new MuninServiceBuilder(services));
+
+    return services;
+  }
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninServiceBuilder.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninServiceBuilder.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+internal sealed class MuninServiceBuilder : IMuninServiceBuilder {
+  public IServiceCollection Services { get; }
+
+  public MuninServiceBuilder(IServiceCollection services)
+  {
+    Services = services ?? throw new ArgumentNullException(nameof(services));
+  }
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.csproj
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.csproj
@@ -32,8 +32,9 @@ This library also provides abstraction APIs for implementing Munin-Plugin. By us
 
   <ItemGroup>
     <PackageReference Include="System.IO.Pipelines" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
     <PackageReference Include="Smdn.Fundamental.Encoding.Buffer" Version="[3.0.0,4.0.0)" Condition="$(TargetFramework.StartsWith('net4')) or $(TargetFramework.StartsWith('netstandard'))" />
     <PackageReference Include="Smdn.Fundamental.Exception" Version="[3.0.0,4.0.0)" />
   </ItemGroup>

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/IMuninNode.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/IMuninNode.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 using System;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Smdn.Net.MuninNode;
 
@@ -39,4 +41,40 @@ public interface IMuninNode {
   /// Attempted to read a property value after the instance was disposed.
   /// </exception>
   EndPoint EndPoint { get; }
+
+  // suppress warnings due to the absence of `ConfigureAwaitOptions`.
+#if SYSTEM_THREADING_TASKS_CONFIGUREAWAITOPTIONS
+#pragma warning disable CS0419
+#else
+#pragma warning disable CS1574
+#endif
+
+  /// <summary>
+  /// Runs a <c>Munin-Node</c> instance and returns a <see cref="Task"/> that processes
+  /// requests from the <c>munin master</c> and only completes when the
+  /// <paramref name="cancellationToken"/> is triggered.
+  /// </summary>
+  /// <param name="cancellationToken">
+  /// The <see cref="CancellationToken"/> to trigger stopping <c>Munin-Node</c>.
+  /// </param>
+  /// <remarks>
+  ///   <para>
+  ///     This method continues to wait for a connection from the client unless a
+  ///     cancellation request is made by <paramref name="cancellationToken"/>.
+  ///   </para>
+  ///   <para>
+  ///     If the cancellation request is made by <paramref name="cancellationToken"/>,
+  ///     an <see cref="OperationCanceledException"/> will be thrown even if the operation ends successfully.
+  ///     Therefore, if you do not want an exception to be thrown due to an intentional stop
+  ///     caused by a cancellation request, call <see cref="Task.ConfigureAwait"/>
+  ///     with <see cref="ConfigureAwaitOptions.SuppressThrowing"/> for the <see cref="Task"/>
+  ///     returned by this method.
+  ///   </para>
+  /// </remarks>
+  /// <returns>
+  /// A <see cref="Task"/> that represents the the server task that handles connections and
+  /// requests to the <c>Munin-Node</c> implementation provided by this instance asynchronously.
+  /// </returns>
+#pragma warning restore CS1574, CS0419
+  Task RunAsync(CancellationToken cancellationToken);
 }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/IMuninNode.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/IMuninNode.cs
@@ -1,5 +1,8 @@
 // SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+using System;
+using System.Net;
+
 namespace Smdn.Net.MuninNode;
 
 /// <summary>
@@ -21,4 +24,19 @@ public interface IMuninNode {
   /// </para>
   /// </remarks>
   string HostName { get; }
+
+  /// <summary>
+  /// Gets the <see cref="EndPoint"/> object representing the endpoint of the <c>Munin-Node</c>.
+  /// </summary>
+  /// <exception cref="InvalidOperationException">
+  /// This instance is not running, or the state of the this instance is such that
+  /// the endpoint cannot be get.
+  /// </exception>
+  /// <exception cref="NotSupportedException">
+  /// Getting endpoint from this instance is not supported.
+  /// </exception>
+  /// <exception cref="ObjectDisposedException">
+  /// Attempted to read a property value after the instance was disposed.
+  /// </exception>
+  EndPoint EndPoint { get; }
 }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/MuninNodeOptions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/MuninNodeOptions.cs
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+
+using Smdn.Net.MuninNode.AccessRules;
+
+namespace Smdn.Net.MuninNode;
+
+/// <summary>
+/// Options to configure the <c>Munin-Node</c>.
+/// </summary>
+/// <see cref="DependencyInjection.IMuninServiceBuilderExtensions.AddNode(DependencyInjection.IMuninServiceBuilder, Action{MuninNodeOptions})"/>
+public sealed class MuninNodeOptions {
+  private static IPAddress LoopbackAddress => Socket.OSSupportsIPv6 ? IPAddress.IPv6Loopback : IPAddress.Loopback;
+  private static IPAddress AnyAddress => Socket.OSSupportsIPv6 ? IPAddress.IPv6Any : IPAddress.Any;
+
+  private static int ValidatePort(int port, string paramName)
+  {
+    if (port is < IPEndPoint.MinPort or > IPEndPoint.MaxPort)
+      throw new ArgumentOutOfRangeException(paramName: paramName, actualValue: port, $"must be in range of {IPEndPoint.MinPort}~{IPEndPoint.MaxPort}");
+
+    return port;
+  }
+
+  /// <value>
+  /// <see cref="IPAddress.IPv6Loopback"/> if the operating system supports IPv6, otherwise <see cref="IPAddress.Loopback"/>.
+  /// </value>
+  public static IPAddress DefaultAddress => LoopbackAddress;
+
+  public const string DefaultHostName = "munin-node.localhost";
+  public const int DefaultPort = 4949;
+
+  /// <summary>
+  /// Gets or sets a value for the <c>host</c>.
+  /// The <see cref="IPAddress"/> on which the <c>Munin-Node</c> listens.
+  /// </summary>
+  /// <seealso cref="DefaultAddress"/>
+  /// <seealso href="https://guide.munin-monitoring.org/en/latest/reference/munin-node.conf.html#cmdoption-arg-host">munin-node.conf - DIRECTIVES - Native - host</seealso>
+  public IPAddress Address {
+    get => address;
+    set => address = value ?? throw new ArgumentNullException(nameof(Address));
+  }
+
+  private IPAddress address = DefaultAddress;
+
+  /// <summary>
+  /// Gets or sets a value for the <c>port</c>.
+  /// The TCP port number on which the <c>Munin-Node</c> listens.
+  /// </summary>
+  /// <remarks>
+  /// The default value is <c>4949</c>.
+  /// </remarks>
+  /// <seealso href="https://guide.munin-monitoring.org/en/latest/reference/munin-node.conf.html#cmdoption-arg-port">munin-node.conf - DIRECTIVES - Inherited - port</seealso>
+  public int Port {
+    get => port;
+    set => port = ValidatePort(value, nameof(Port));
+  }
+
+  private int port = DefaultPort;
+
+  /// <summary>
+  /// Gets or sets a value for the <c>host_name</c>.
+  /// The hostname used by <c>Munin-Node</c> to advertise itself to the munin master.
+  /// </summary>
+  /// <remarks>
+  /// The default value is <c>munin-node.localhost</c>.
+  /// </remarks>
+  /// <value>
+  /// The hostname used by <c>Munin-Node</c>. The length of the string must be at least 1.
+  /// </value>
+  /// <seealso href="https://guide.munin-monitoring.org/en/latest/reference/munin-node.conf.html#cmdoption-arg-host-name">munin-node.conf - DIRECTIVES - Native - host_name</seealso>
+  public string HostName {
+    get => hostName;
+    set {
+      if (value is null)
+        throw new ArgumentNullException(nameof(HostName));
+      if (value.Length == 0)
+        throw ExceptionUtils.CreateArgumentMustBeNonEmptyString(nameof(HostName));
+
+      hostName = value;
+    }
+  }
+
+  private string hostName = DefaultHostName;
+
+  /// <summary>
+  /// Gets or sets an <see cref="IAccessRule"/> that determines whether to accept or reject a remote host connecting to munin-node.
+  /// </summary>
+  /// <seealso href="https://guide.munin-monitoring.org/en/latest/reference/munin-node.conf.html#cmdoption-arg-allow">munin-node.conf - DIRECTIVES - Inherited - allow</seealso>
+  /// <seealso href="https://guide.munin-monitoring.org/en/latest/reference/munin-node.conf.html#cmdoption-arg-cidr-allow">munin-node.conf - DIRECTIVES - Inherited - cidr_allow</seealso>
+  /// <seealso href="https://guide.munin-monitoring.org/en/latest/reference/munin-node.conf.html#cmdoption-arg-cidr-deny">munin-node.conf - DIRECTIVES - Inherited - cidr_deny</seealso>
+  public IAccessRule? AccessRule { get; set; }
+
+#if false && TODO
+  /// <summary>
+  /// Gets or sets a value for the <c>timeout</c>.
+  /// The timeout value for each plugin. If plugins take longer to run, this will disconnect the master.
+  /// </summary>
+  /// <remarks>
+  /// The default value is 60 seconds.
+  /// </remarks>
+  /// <seealso href="https://guide.munin-monitoring.org/en/latest/reference/munin-node.conf.html#cmdoption-arg-timeout">munin-node.conf - DIRECTIVES - Native - timeout</seealso>
+  public TimeSpan TimeoutForPlugin { get; internal set; } = TimeSpan.FromSeconds(60);
+
+  /// <summary>
+  /// Gets or sets a value for the <c>global_timeout</c>.
+  /// The timeout value for the entire session from the start to the end of the <c>munin-update</c> process.
+  /// </summary>
+  /// <remarks>
+  /// The default value is 900 seconds.
+  /// </remarks>
+  /// <seealso href="https://guide.munin-monitoring.org/en/latest/reference/munin-node.conf.html#cmdoption-arg-global-timeout">munin-node.conf - DIRECTIVES - Native - global_timeout</seealso>
+  /// <seealso cref="Smdn.Net.MuninPlugin.INodeSessionCallback"/>
+  public TimeSpan TimeoutForSession { get; internal set; } = TimeSpan.FromSeconds(900);
+#endif
+
+  public MuninNodeOptions()
+  {
+  }
+
+#if false
+  public MuninNodeOptions Clone()
+    => (MuninNodeOptions)MemberwiseClone();
+#endif
+
+  /// <summary>
+  /// Set the value of the <see cref="Address"/> property to use the address of
+  /// <see cref="IPAddress.Any"/> or <see cref="IPAddress.IPv6Any"/>.
+  /// </summary>
+  /// <remarks>
+  /// If <see cref="Socket.OSSupportsIPv6"/> is <see langword="true"/>, <see cref="IPAddress.IPv6Any"/>
+  /// will be used, otherwise <see cref="IPAddress.Any"/> will be used.
+  /// </remarks>
+  /// <returns>
+  /// The current <see cref="MuninNodeOptions"/> so that additional calls can be chained.
+  /// </returns>
+  public MuninNodeOptions UseAnyAddress()
+  {
+    Address = AnyAddress;
+
+    return this;
+  }
+
+  /// <summary>
+  /// Set the value of the <see cref="Address"/> property to use the address of
+  /// <see cref="IPAddress.Any"/> or <see cref="IPAddress.IPv6Any"/>.
+  /// </summary>
+  /// <param name="port">
+  /// The port number to be used as the endpoint along with the address.
+  /// This value will be set to the value of the <see cref="Port"/> property.
+  /// </param>
+  /// <remarks>
+  /// If <see cref="Socket.OSSupportsIPv6"/> is <see langword="true"/>, <see cref="IPAddress.IPv6Any"/>
+  /// will be used, otherwise <see cref="IPAddress.Any"/> will be used.
+  /// </remarks>
+  /// <returns>
+  /// The current <see cref="MuninNodeOptions"/> so that additional calls can be chained.
+  /// </returns>
+  public MuninNodeOptions UseAnyAddress(int port)
+  {
+    Port = ValidatePort(port, nameof(port));
+    Address = AnyAddress;
+
+    return this;
+  }
+
+  /// <summary>
+  /// Set the value of the <see cref="Address"/> property to use the loopback address.
+  /// </summary>
+  /// <remarks>
+  /// If <see cref="Socket.OSSupportsIPv6"/> is <see langword="true"/>, <see cref="IPAddress.IPv6Loopback"/>
+  /// will be used, otherwise <see cref="IPAddress.Loopback"/> will be used.
+  /// </remarks>
+  /// <returns>
+  /// The current <see cref="MuninNodeOptions"/> so that additional calls can be chained.
+  /// </returns>
+  public MuninNodeOptions UseLoopbackAddress()
+  {
+    Address = LoopbackAddress;
+
+    return this;
+  }
+
+  /// <summary>
+  /// Set the value of the <see cref="Address"/> property to use the loopback address.
+  /// </summary>
+  /// <param name="port">
+  /// The port number to be used as the endpoint along with the address.
+  /// This value will be set to the value of the <see cref="Port"/> property.
+  /// </param>
+  /// <remarks>
+  /// If <see cref="Socket.OSSupportsIPv6"/> is <see langword="true"/>, <see cref="IPAddress.IPv6Loopback"/>
+  /// will be used, otherwise <see cref="IPAddress.Loopback"/> will be used.
+  /// </remarks>
+  /// <returns>
+  /// The current <see cref="MuninNodeOptions"/> so that additional calls can be chained.
+  /// </returns>
+  public MuninNodeOptions UseLoopbackAddress(int port)
+  {
+    Port = ValidatePort(port, nameof(port));
+    Address = LoopbackAddress;
+
+    return this;
+  }
+
+  /// <summary>
+  /// Set the <see cref="AccessRule"/> property to allow access only from the specified address.
+  /// </summary>
+  /// <param name="addresses">
+  /// The <see cref="IReadOnlyList{IPAddress}"/> indicates the read-only list of addresses
+  /// allowed to access <c>Munin-Node</c>.
+  /// </param>
+  /// <param name="shouldConsiderIPv4MappedIPv6Address">
+  /// Specifies whether or not to be aware that the IP address to be an IPv4-mapped IPv6 address or not
+  /// when comparing IP addresses.
+  /// </param>
+  /// <returns>
+  /// The current <see cref="MuninNodeOptions"/> so that additional calls can be chained.
+  /// </returns>
+  public MuninNodeOptions AllowFrom(
+    IReadOnlyList<IPAddress> addresses,
+    bool shouldConsiderIPv4MappedIPv6Address = true
+  )
+  {
+    AccessRule = new AddressListAccessRule(
+      addresses ?? throw new ArgumentNullException(nameof(addresses)),
+      shouldConsiderIPv4MappedIPv6Address
+    );
+
+    return this;
+  }
+
+  /// <summary>
+  /// Set the <see cref="AccessRule"/> property to allow access only from the loopback address.
+  /// </summary>
+  /// <returns>
+  /// The current <see cref="MuninNodeOptions"/> so that additional calls can be chained.
+  /// </returns>
+  public MuninNodeOptions AllowFromLoopbackOnly()
+  {
+    AccessRule = LoopbackOnlyAccessRule.Instance;
+
+    return this;
+  }
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.Obsolete.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.Obsolete.cs
@@ -62,6 +62,9 @@ partial class NodeBase {
     }
   }
 
+  [Obsolete($"Use {nameof(EndPoint)} instead.")]
+  public EndPoint LocalEndPoint => EndPoint;
+
   [Obsolete($"Use {nameof(IMuninNodeListenerFactory)} and {nameof(StartAsync)} instead.")]
   protected virtual Socket CreateServerSocket()
     => throw new NotImplementedException(

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
@@ -208,6 +208,27 @@ public abstract partial class NodeBase : IMuninNode, IDisposable, IAsyncDisposab
     }
   }
 
+  /// <inheritdoc cref="IMuninNode.RunAsync(CancellationToken)"/>
+  /// <seealso cref="IMuninNode.RunAsync(CancellationToken)"/>
+  /// <seealso cref="StartAsync(CancellationToken)"/>
+  /// <seealso cref="AcceptAsync(bool,CancellationToken)"/>
+  public Task RunAsync(CancellationToken cancellationToken)
+  {
+    ThrowIfDisposed();
+
+    return RunAsyncCore(cancellationToken);
+
+    async Task RunAsyncCore(CancellationToken ct)
+    {
+      await StartAsync(ct).ConfigureAwait(false);
+
+      await AcceptAsync(
+        throwIfCancellationRequested: true,
+        cancellationToken: ct
+      ).ConfigureAwait(false);
+    }
+  }
+
   /// <summary>
   /// Starts accepting multiple sessions.
   /// The <see cref="ValueTask" /> this method returns will never complete unless the cancellation requested by the <paramref name="cancellationToken" />.

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
@@ -64,20 +64,11 @@ public abstract partial class NodeBase : IMuninNode, IDisposable, IAsyncDisposab
     }
   }
 
-  /// <summary>
-  /// Gets the <see cref="EndPoint"/> actually bound with the current instance.
-  /// </summary>
-  /// <exception cref="InvalidOperationException">
-  /// The <see cref="Start"/> or <see cref="StartAsync"/> method has not been called.
-  /// </exception>
-  /// <exception cref="NotSupportedException">
-  /// Getting endpoint from this instance is not supported.
-  /// </exception>
-  /// <exception cref="ObjectDisposedException">
-  /// Attempted to read a property value after the instance was disposed.
-  /// </exception>
+  /// <inheritdoc cref="IMuninNode.EndPoint"/>
   /// <seealso cref="GetLocalEndPointToBind"/>
-  public EndPoint LocalEndPoint {
+  /// <seealso cref="Start"/>
+  /// <seealso cref="StartAsync"/>
+  public EndPoint EndPoint {
     get {
       ThrowIfDisposed();
 

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/AggregatePluginProvider.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/AggregatePluginProvider.cs
@@ -15,7 +15,7 @@ namespace Smdn.Net.MuninPlugin;
 /// wrap them as a single <see cref="IPluginProvider"/>.
 /// </summary>
 #pragma warning disable IDE0055
-public sealed class ReadOnlyPluginProviderCollection :
+public sealed class AggregatePluginProvider :
   ReadOnlyCollection<IPluginProvider>,
   INodeSessionCallback,
   IPluginProvider
@@ -29,9 +29,9 @@ public sealed class ReadOnlyPluginProviderCollection :
   INodeSessionCallback? IPluginProvider.SessionCallback => this;
 
   /*
-   * ReadOnlyPluginProviderCollection members
+   * AggregatePluginProvider members
    */
-  public ReadOnlyPluginProviderCollection(IList<IPluginProvider> pluginProviders)
+  public AggregatePluginProvider(IList<IPluginProvider> pluginProviders)
     : base(pluginProviders ?? throw new ArgumentNullException(nameof(pluginProviders)))
   {
     Plugins = Items.SelectMany(static provider => provider.Plugins).ToList();

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/ReadOnlyPluginProviderCollection.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/ReadOnlyPluginProviderCollection.cs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smdn.Net.MuninPlugin;
+
+/// <summary>
+/// Provides a read-only collection of <see cref="IPluginProvider"/>s to aggregate zero or more <see cref="IPluginProvider"/>s and
+/// wrap them as a single <see cref="IPluginProvider"/>.
+/// </summary>
+#pragma warning disable IDE0055
+public sealed class ReadOnlyPluginProviderCollection :
+  ReadOnlyCollection<IPluginProvider>,
+  INodeSessionCallback,
+  IPluginProvider
+{
+#pragma warning restore IDE0055
+  /*
+   * IPluginProvider
+   */
+  public IReadOnlyCollection<IPlugin> Plugins { get; }
+
+  INodeSessionCallback? IPluginProvider.SessionCallback => this;
+
+  /*
+   * ReadOnlyPluginProviderCollection members
+   */
+  public ReadOnlyPluginProviderCollection(IList<IPluginProvider> pluginProviders)
+    : base(pluginProviders ?? throw new ArgumentNullException(nameof(pluginProviders)))
+  {
+    Plugins = Items.SelectMany(static provider => provider.Plugins).ToList();
+  }
+
+  /*
+   * INodeSessionCallback
+   */
+  async ValueTask INodeSessionCallback.ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken)
+  {
+    foreach (var provider in Items) {
+      cancellationToken.ThrowIfCancellationRequested();
+
+      if (provider.SessionCallback is INodeSessionCallback sessionCallback)
+        await sessionCallback.ReportSessionStartedAsync(sessionId, cancellationToken).ConfigureAwait(false);
+    }
+  }
+
+  async ValueTask INodeSessionCallback.ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken)
+  {
+    foreach (var provider in Items) {
+      cancellationToken.ThrowIfCancellationRequested();
+
+      if (provider.SessionCallback is INodeSessionCallback sessionCallback)
+        await sessionCallback.ReportSessionClosedAsync(sessionId, cancellationToken).ConfigureAwait(false);
+    }
+  }
+}

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
@@ -1,0 +1,625 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NUnit.Framework;
+
+using Smdn.Net.MuninNode.Transport;
+using Smdn.Net.MuninPlugin;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+[TestFixture]
+public class IMuninNodeBuilderExtensionsTests {
+  [Test]
+  public void AddPlugin_IPlugin_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder => {
+        var nodeBuilder = builder.AddNode(option => { });
+
+        Assert.That(
+          () => nodeBuilder.AddPlugin(plugin: null!),
+          Throws
+            .ArgumentNullException
+            .With
+            .Property(nameof(ArgumentNullException.ParamName))
+            .EqualTo("plugin")
+        );
+      }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    Assert.That(
+      () => serviceProvider.GetService<IMuninNode>(),
+      Throws.Nothing
+    );
+  }
+
+  private class PseudoPlugin(IServiceProvider? serviceProvider = null) : IPlugin {
+    public IServiceProvider? ServiceProvider => serviceProvider;
+    public string Name => "pseudo-plugin";
+    public IPluginGraphAttributes GraphAttributes => throw new NotImplementedException();
+    public IPluginDataSource DataSource => throw new NotImplementedException();
+    public INodeSessionCallback? SessionCallback => null;
+  }
+
+  [Test]
+  public void AddPlugin_IPlugin()
+  {
+    var services = new ServiceCollection();
+    var plugin = new PseudoPlugin();
+
+    services.AddMunin(
+      builder =>
+        builder
+          .AddNode(option => { })
+          .AddPlugin(plugin)
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = (NodeBase)serviceProvider.GetRequiredService<IMuninNode>();
+
+    Assert.That(node.PluginProvider.Plugins.Count, Is.EqualTo(1));
+    Assert.That(node.PluginProvider.Plugins.First(), Is.SameAs(plugin));
+  }
+
+  [Test]
+  public void AddPlugin_FuncBuildPlugin_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder => {
+        var nodeBuilder = builder.AddNode(option => { });
+
+        Assert.That(
+          () => nodeBuilder.AddPlugin(buildPlugin: null!),
+          Throws
+            .ArgumentNullException
+            .With
+            .Property(nameof(ArgumentNullException.ParamName))
+            .EqualTo("buildPlugin")
+        );
+      }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    Assert.That(
+      () => serviceProvider.GetService<IMuninNode>(),
+      Throws.Nothing
+    );
+  }
+
+  [Test]
+  public void AddPlugin_FuncBuildPlugin()
+  {
+    var services = new ServiceCollection();
+    PseudoPlugin? plugin = null;
+
+    services.AddMunin(
+      builder =>
+        builder
+          .AddNode(option => { })
+          .AddPlugin(serviceProvider => {
+            plugin = new PseudoPlugin(serviceProvider);
+
+            return plugin;
+          })
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = (NodeBase)serviceProvider.GetRequiredService<IMuninNode>();
+
+    Assert.That(node.PluginProvider.Plugins.Count, Is.EqualTo(1));
+    Assert.That(node.PluginProvider.Plugins.First(), Is.SameAs(plugin));
+
+    Assert.That(plugin, Is.Not.Null);
+    Assert.That(plugin.ServiceProvider, Is.Not.Null);
+    Assert.That(plugin.ServiceProvider.GetRequiredService<IMuninNode>, Throws.Nothing);
+  }
+
+  [Test]
+  public void UsePluginProvider_IPluginProvider_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder => {
+        var nodeBuilder = builder.AddNode(option => { });
+
+        Assert.That(
+          () => nodeBuilder.UsePluginProvider(pluginProvider: null!),
+          Throws
+            .ArgumentNullException
+            .With
+            .Property(nameof(ArgumentNullException.ParamName))
+            .EqualTo("pluginProvider")
+        );
+      }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    Assert.That(
+      () => serviceProvider.GetService<IMuninNode>(),
+      Throws.Nothing
+    );
+  }
+
+  private class PseudoPluginProvider(IServiceProvider? serviceProvider = null) : IPluginProvider {
+    public IServiceProvider? ServiceProvider => serviceProvider;
+    public IReadOnlyCollection<IPlugin> Plugins => throw new NotImplementedException();
+    public INodeSessionCallback? SessionCallback => throw new NotImplementedException();
+  }
+
+  [Test]
+  public void UsePluginProvider_IPluginProvider()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder =>
+        builder
+          .AddNode(option => { })
+          .UsePluginProvider(new PseudoPluginProvider())
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = (NodeBase)serviceProvider.GetRequiredService<IMuninNode>();
+
+    Assert.That(node.PluginProvider, Is.Not.Null);
+    Assert.That(
+      () => _ = node.PluginProvider.Plugins,
+      Throws.TypeOf<NotImplementedException>()
+    );
+    Assert.That(
+      () => _ = node.PluginProvider.SessionCallback,
+      Throws.TypeOf<NotImplementedException>()
+    );
+  }
+
+  [Test]
+  public void UsePluginProvider_FuncBuildPluginProvider_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder => {
+        var nodeBuilder = builder.AddNode(option => { });
+
+        Assert.That(
+          () => nodeBuilder.UsePluginProvider(buildPluginProvider: null!),
+          Throws
+            .ArgumentNullException
+            .With
+            .Property(nameof(ArgumentNullException.ParamName))
+            .EqualTo("buildPluginProvider")
+        );
+      }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    Assert.That(
+      () => serviceProvider.GetService<IMuninNode>(),
+      Throws.Nothing
+    );
+  }
+
+  [Test]
+  public void UsePluginProvider_FuncBuildPluginProvider_IPluginProvider()
+  {
+    var services = new ServiceCollection();
+    PseudoPluginProvider? pluginProvider = null;
+
+    services.AddMunin(
+      builder =>
+        builder
+          .AddNode(option => { })
+          .UsePluginProvider(serviceProvider => {
+            pluginProvider = new PseudoPluginProvider(serviceProvider);
+
+            return pluginProvider;
+          })
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = (NodeBase)serviceProvider.GetRequiredService<IMuninNode>();
+
+    Assert.That(node.PluginProvider, Is.Not.Null);
+    Assert.That(node.PluginProvider, Is.SameAs(pluginProvider));
+
+    Assert.That(pluginProvider!.ServiceProvider, Is.Not.Null);
+    Assert.That(pluginProvider.ServiceProvider.GetRequiredService<IMuninNode>, Throws.Nothing);
+  }
+
+  [Test]
+  public void UseSessionCallback_INodeSessionCallback_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder => {
+        var nodeBuilder = builder.AddNode(option => { });
+
+        Assert.That(
+          () => nodeBuilder.UseSessionCallback(sessionCallback: null!),
+          Throws
+            .ArgumentNullException
+            .With
+            .Property(nameof(ArgumentNullException.ParamName))
+            .EqualTo("sessionCallback")
+        );
+      }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    Assert.That(
+      () => serviceProvider.GetService<IMuninNode>(),
+      Throws.Nothing
+    );
+  }
+
+  private class SessionCallback(IServiceProvider? serviceProvider = null) : INodeSessionCallback {
+    public IServiceProvider? ServiceProvider => serviceProvider;
+
+    public ValueTask ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken)
+      => throw new NotImplementedException();
+
+    public ValueTask ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken)
+      => throw new NotImplementedException();
+  }
+
+  [Test]
+  public void UseSessionCallback_INodeSessionCallback()
+  {
+    var services = new ServiceCollection();
+    var sessionCallback = new SessionCallback();
+
+    services.AddMunin(
+      builder =>
+        builder
+          .AddNode(option => { })
+          .UseSessionCallback(sessionCallback)
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = (NodeBase)serviceProvider.GetRequiredService<IMuninNode>();
+
+    Assert.That(node.PluginProvider.SessionCallback, Is.Not.Null);
+    Assert.That(node.PluginProvider.SessionCallback, Is.SameAs(sessionCallback));
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_UseSessionCallback_FuncSessionCallback()
+  {
+    yield return new object[] {
+      (IMuninNodeBuilder builder) => {
+        builder.UseSessionCallback(
+          reportSessionStartedAsyncFunc: null,
+          reportSessionClosedAsyncFunc: null
+        );
+      },
+      (NodeBase node) => {
+        Assert.That(node.PluginProvider.SessionCallback, Is.Not.Null);
+        Assert.That(
+          async () => await node.PluginProvider.SessionCallback.ReportSessionStartedAsync("started", default),
+          Throws.Nothing
+        );
+        Assert.That(
+          async () => await node.PluginProvider.SessionCallback.ReportSessionClosedAsync("closed", default),
+          Throws.Nothing
+        );
+      }
+    };
+
+    yield return new object[] {
+      (IMuninNodeBuilder builder) => {
+        builder.UseSessionCallback(
+          reportSessionStartedAsyncFunc: (sessionId, ct) => throw new NotImplementedException($"sessionId={sessionId}"),
+          reportSessionClosedAsyncFunc: null
+        );
+      },
+      (NodeBase node) => {
+        Assert.That(node.PluginProvider.SessionCallback, Is.Not.Null);
+        Assert.That(
+          async () => await node.PluginProvider.SessionCallback.ReportSessionStartedAsync("session-started", default),
+          Throws
+            .TypeOf<NotImplementedException>()
+            .With
+            .Property(nameof(NotImplementedException.Message))
+            .EqualTo("sessionId=session-started")
+        );
+        Assert.That(
+          async () => await node.PluginProvider.SessionCallback.ReportSessionClosedAsync("session-closed", default),
+          Throws.Nothing
+        );
+      }
+    };
+
+    yield return new object[] {
+      (IMuninNodeBuilder builder) => {
+        builder.UseSessionCallback(
+          reportSessionStartedAsyncFunc: null,
+          reportSessionClosedAsyncFunc: (sessionId, ct) => throw new NotImplementedException($"sessionId={sessionId}")
+        );
+      },
+      (NodeBase node) => {
+        Assert.That(node.PluginProvider.SessionCallback, Is.Not.Null);
+        Assert.That(
+          async () => await node.PluginProvider.SessionCallback.ReportSessionStartedAsync("session-started", default),
+          Throws.Nothing
+        );
+        Assert.That(
+          async () => await node.PluginProvider.SessionCallback.ReportSessionClosedAsync("session-closed", default),
+          Throws
+            .TypeOf<NotImplementedException>()
+            .With
+            .Property(nameof(NotImplementedException.Message))
+            .EqualTo("sessionId=session-closed")
+        );
+      }
+    };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_UseSessionCallback_FuncSessionCallback))]
+  public void UseSessionCallback_FuncSessionCallback(
+    Action<IMuninNodeBuilder> callUseSessionCallback,
+    Action<NodeBase> assertBuiltNode
+  )
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder => callUseSessionCallback(builder.AddNode(option => { }))
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = (NodeBase)serviceProvider.GetRequiredService<IMuninNode>();
+
+    assertBuiltNode(node);
+  }
+
+  [Test]
+  public void UseSessionCallback_FuncBuildSessionCallback_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder => {
+        var nodeBuilder = builder.AddNode(option => { });
+
+        Assert.That(
+          () => nodeBuilder.UseSessionCallback(buildSessionCallback: null!),
+          Throws
+            .ArgumentNullException
+            .With
+            .Property(nameof(ArgumentNullException.ParamName))
+            .EqualTo("buildSessionCallback")
+        );
+      }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    Assert.That(
+      () => serviceProvider.GetService<IMuninNode>(),
+      Throws.Nothing
+    );
+  }
+
+  [Test]
+  public void UseSessionCallback_FuncBuildSessionCallback()
+  {
+    var services = new ServiceCollection();
+    SessionCallback? sessionCallback = null;
+
+    services.AddMunin(
+      builder =>
+        builder
+          .AddNode(option => { })
+          .UseSessionCallback(buildSessionCallback: serviceProvider => {
+            sessionCallback = new SessionCallback(serviceProvider);
+
+            return sessionCallback;
+          })
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = (NodeBase)serviceProvider.GetRequiredService<IMuninNode>();
+
+    Assert.That(node.PluginProvider.SessionCallback, Is.Not.Null);
+    Assert.That(node.PluginProvider.SessionCallback, Is.SameAs(sessionCallback));
+    Assert.That(sessionCallback!.ServiceProvider, Is.Not.Null);
+    Assert.That(sessionCallback!.ServiceProvider!.GetRequiredService<IMuninNode>, Throws.Nothing);
+  }
+
+  [Test]
+  public void UseListenerFactory_IMuninNodeListenerFactory_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder => {
+        var nodeBuilder = builder.AddNode(option => { });
+
+        Assert.That(
+          () => nodeBuilder.UseListenerFactory(listenerFactory: null!),
+          Throws
+            .ArgumentNullException
+            .With
+            .Property(nameof(ArgumentNullException.ParamName))
+            .EqualTo("listenerFactory")
+        );
+      }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    Assert.That(
+      () => serviceProvider.GetService<IMuninNode>(),
+      Throws.Nothing
+    );
+  }
+
+  private class PseudoListenerFactoryNotImplementedException : NotImplementedException {
+  }
+
+  private class PseudoListenerFactory(IServiceProvider? serviceProvider = null) : IMuninNodeListenerFactory {
+    public IServiceProvider? ServiceProvider => serviceProvider;
+
+    public ValueTask<IMuninNodeListener> CreateAsync(
+      EndPoint endPoint,
+      IMuninNode node,
+      CancellationToken cancellationToken
+    )
+      => throw new PseudoListenerFactoryNotImplementedException();
+  }
+
+  [Test]
+  [CancelAfter(1000)]
+  public void UseListenerFactory_IMuninNodeListenerFactory(CancellationToken cancellationToken)
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder =>
+        builder
+          .AddNode(option => { })
+          .UseListenerFactory(new PseudoListenerFactory())
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = serviceProvider.GetRequiredService<IMuninNode>();
+
+    Assert.That(
+      async () => await node.RunAsync(cancellationToken),
+      Throws.TypeOf<PseudoListenerFactoryNotImplementedException>()
+    );
+  }
+
+  [Test]
+  public void UseListenerFactory_FuncBuildListenerFactory_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder => {
+        var nodeBuilder = builder.AddNode(option => { });
+
+        Assert.That(
+          () => nodeBuilder.UseListenerFactory(buildListenerFactory: null!),
+          Throws
+            .ArgumentNullException
+            .With
+            .Property(nameof(ArgumentNullException.ParamName))
+            .EqualTo("buildListenerFactory")
+        );
+      }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    Assert.That(
+      () => serviceProvider.GetService<IMuninNode>(),
+      Throws.Nothing
+    );
+  }
+
+  [Test]
+  [CancelAfter(1000)]
+  public void UseListenerFactory_FuncBuildListenerFactory(CancellationToken cancellationToken)
+  {
+    var services = new ServiceCollection();
+    PseudoListenerFactory? listenerFactory = null;
+
+    services.AddMunin(
+      builder =>
+        builder
+          .AddNode(option => { })
+          .UseListenerFactory(serviceProvider => {
+            listenerFactory = new PseudoListenerFactory(serviceProvider);
+
+            return listenerFactory;
+          })
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = serviceProvider.GetRequiredService<IMuninNode>();
+
+    Assert.That(
+      async () => await node.RunAsync(cancellationToken),
+      Throws.TypeOf<PseudoListenerFactoryNotImplementedException>()
+    );
+
+    Assert.That(listenerFactory!.ServiceProvider, Is.Not.Null);
+    Assert.That(listenerFactory!.ServiceProvider!.GetRequiredService<IMuninNode>, Throws.Nothing);
+  }
+
+  [Test]
+  public void UseListenerFactory_FuncCreateListenerAsync_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(
+      builder => {
+        var nodeBuilder = builder.AddNode(option => { });
+
+        Assert.That(
+          () => nodeBuilder.UseListenerFactory(createListenerAsyncFunc: null!),
+          Throws
+            .ArgumentNullException
+            .With
+            .Property(nameof(ArgumentNullException.ParamName))
+            .EqualTo("createListenerAsyncFunc")
+        );
+      }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    Assert.That(
+      () => serviceProvider.GetService<IMuninNode>(),
+      Throws.Nothing
+    );
+  }
+
+  [Test]
+  [CancelAfter(1000)]
+  public void UseListenerFactory_FuncCreateListenerAsync(CancellationToken cancellationToken)
+  {
+    var services = new ServiceCollection();
+    const string Message = nameof(UseListenerFactory_FuncCreateListenerAsync);
+
+    services.AddMunin(
+      builder =>
+        builder
+          .AddNode(option => { })
+          .UseListenerFactory(createListenerAsyncFunc: (_, _, _, _) => throw new NotSupportedException(Message))
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = serviceProvider.GetRequiredService<IMuninNode>();
+
+    Assert.That(
+      async () => await node.RunAsync(cancellationToken),
+      Throws
+        .TypeOf<NotSupportedException>()
+        .With
+        .Property(nameof(NotSupportedException.Message))
+        .EqualTo(Message)
+    );
+  }
+}

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
@@ -28,6 +28,42 @@ public class IMuninServiceBuilderExtensionsTests {
     });
   }
 
+  [TestCase("_")]
+  [TestCase("munin-node.localhost")]
+  public void AddNode_IMuninNodeBuilderServiceKey(string hostname)
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(configure: builder => {
+      var nodeBuilder = builder.AddNode(configure: options => options.HostName = hostname);
+
+      Assert.That(nodeBuilder.ServiceKey, Is.EqualTo(hostname));
+    });
+  }
+
+  [Test]
+  public void AddNode_PostConfigure_MuninNodeOptions()
+  {
+    const string HostNameForServiceKeyAndOptionName = "munin-node.localhost";
+    const string HostNameForPostConfigure = "postconfigure.munin-node.localhost";
+
+    var services = new ServiceCollection();
+
+    services.AddMunin(configure: builder => {
+      builder.AddNode(configure: options => options.HostName = HostNameForServiceKeyAndOptionName);
+    });
+
+    services.PostConfigure<MuninNodeOptions>(
+      name: HostNameForServiceKeyAndOptionName,
+      configureOptions: options => options.HostName = HostNameForPostConfigure
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = serviceProvider.GetRequiredService<IMuninNode>();
+
+    Assert.That(node.HostName, Is.EqualTo(HostNameForPostConfigure));
+  }
+
   [Test]
   public void AddNode_GetService()
   {

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Linq;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NUnit.Framework;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+[TestFixture]
+public class IMuninServiceBuilderExtensionsTests {
+  [Test]
+  public void AddNode_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(configure: builder => {
+      Assert.That(
+        () => builder.AddNode(configure: null!),
+        Throws
+          .ArgumentNullException
+          .With
+          .Property(nameof(ArgumentNullException.ParamName))
+          .EqualTo("configure")
+      );
+    });
+  }
+
+  [Test]
+  public void AddNode_GetService()
+  {
+    var services = new ServiceCollection();
+
+    services.AddMunin(configure: builder => {
+      builder.AddNode();
+    });
+
+    var serviceProvider = services.BuildServiceProvider();
+    var firstNode = serviceProvider.GetService<IMuninNode>();
+    var secondNode = serviceProvider.GetService<IMuninNode>();
+
+    Assert.That(firstNode, Is.Not.Null);
+    Assert.That(secondNode, Is.Not.SameAs(firstNode));
+  }
+
+  [Test]
+  public void AddNode_GetKeyedService()
+  {
+    const string HostName = "munin-node.localhost";
+    var services = new ServiceCollection();
+
+    services.AddMunin(configure: builder => {
+      builder.AddNode(options => options.HostName = HostName);
+    });
+
+    var serviceProvider = services.BuildServiceProvider();
+    var firstNode = serviceProvider.GetKeyedService<IMuninNode>(HostName);
+    var secondNode = serviceProvider.GetKeyedService<IMuninNode>(HostName);
+
+    Assert.That(firstNode, Is.Not.Null);
+    Assert.That(firstNode.HostName, Is.EqualTo(HostName));
+    Assert.That(secondNode, Is.SameAs(firstNode));
+  }
+
+  [Test]
+  public void AddNode_DuplicateHostName()
+  {
+    const string HostName = "munin-node.localhost";
+    var services = new ServiceCollection();
+
+    services.AddMunin(configure: builder => {
+      builder.AddNode(options => options.HostName = HostName);
+      builder.AddNode(options => options.HostName = HostName); // should throw exception?
+    });
+
+    var serviceProvider = services.BuildServiceProvider();
+    var firstNode = serviceProvider.GetKeyedService<IMuninNode>(HostName);
+    var secondNode = serviceProvider.GetKeyedService<IMuninNode>(HostName);
+
+    Assert.That(firstNode, Is.Not.Null);
+    Assert.That(firstNode.HostName, Is.EqualTo(HostName));
+    Assert.That(secondNode, Is.SameAs(firstNode));
+  }
+
+  [Test]
+  public void AddNode_Multiple_GetServices()
+  {
+    var services = new ServiceCollection();
+
+    const string HostName0 = "0.munin-node.localhost";
+    const string HostName1 = "1.munin-node.localhost";
+
+    services.AddMunin(configure: builder => {
+      builder.AddNode(options => options.HostName = HostName0);
+      builder.AddNode(options => options.HostName = HostName1);
+    });
+
+    var nodes = services.BuildServiceProvider().GetServices<IMuninNode>().ToList();
+
+    Assert.That(nodes, Is.Not.Null);
+    Assert.That(nodes.Count, Is.EqualTo(2));
+    Assert.That(() => nodes.First(node => node.HostName == HostName0), Throws.Nothing);
+    Assert.That(() => nodes.First(node => node.HostName == HostName1), Throws.Nothing);
+  }
+
+  [TestCase("_")]
+  [TestCase("munin-node.localhost")]
+  public void AddNode_Multiple_GetKeyedService(string hostName)
+  {
+    const string AnotherHostName = "another.munin-node.localhost";
+    var services = new ServiceCollection();
+
+    services.AddMunin(configure: builder => {
+      builder.AddNode(options => options.HostName = hostName);
+      builder.AddNode(options => options.HostName = AnotherHostName);
+    });
+
+    var serviceProvider = services.BuildServiceProvider();
+    var node = serviceProvider.GetKeyedService<IMuninNode>(serviceKey: hostName);
+    var anotherNode = serviceProvider.GetKeyedService<IMuninNode>(serviceKey: AnotherHostName);
+
+    Assert.That(node, Is.Not.Null);
+    Assert.That(node.HostName, Is.EqualTo(hostName));
+    Assert.That(node, Is.Not.SameAs(anotherNode));
+  }
+}

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IServiceCollectionExtensions.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IServiceCollectionExtensions.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using Microsoft.Extensions.DependencyInjection;
+
+using NUnit.Framework;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+[TestFixture]
+public class IServiceCollectionExtensionsTests {
+  [Test]
+  public void AddMunin_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    Assert.That(
+      () => services.AddMunin(configure: null!),
+      Throws.ArgumentNullException
+    );
+  }
+
+  [Test]
+  public void AddMunin()
+  {
+    var services = new ServiceCollection();
+
+    var ret = services.AddMunin(configure => { });
+
+    Assert.That(ret, Is.SameAs(services));
+
+    var muninServiceBuilder = services.BuildServiceProvider().GetService<IMuninServiceBuilder>();
+
+    Assert.That(muninServiceBuilder, Is.Null);
+  }
+}

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/MuninNodeOptions.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/MuninNodeOptions.cs
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Net;
+
+using NUnit.Framework;
+
+namespace Smdn.Net.MuninNode;
+
+[TestFixture]
+public class MuninNodeOptionsTests {
+  private static System.Collections.IEnumerable YieldTestCases_ValidPorts()
+  {
+    yield return 0;
+    yield return 1;
+    yield return 65535;
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_InvalidPorts()
+  {
+    yield return -1;
+    yield return 65536;
+  }
+
+  [Test]
+  public void Address()
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(() => options.Address = IPAddress.Any, Throws.Nothing);
+    Assert.That(options.Address, Is.EqualTo(IPAddress.Any));
+  }
+
+  [Test]
+  public void Address_ArgumentNull()
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(
+      () => options.Address = null!,
+      Throws.ArgumentNullException.With.Property(nameof(ArgumentNullException.ParamName)).EqualTo(nameof(options.Address))
+    );
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ValidPorts))]
+  public void Port(int port)
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(() => options.Port = port, Throws.Nothing);
+    Assert.That(options.Port, Is.EqualTo(port));
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_InvalidPorts))]
+  public void Port_ArgumentOutOfRange(int port)
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(
+      () => options.Port = port,
+      Throws
+        .TypeOf<ArgumentOutOfRangeException>()
+        .With
+        .Property(nameof(ArgumentOutOfRangeException.ParamName))
+        .EqualTo(nameof(options.Port))
+        .And
+        .Property(nameof(ArgumentOutOfRangeException.ActualValue))
+        .EqualTo(port)
+    );
+  }
+
+  [TestCase("_")]
+  [TestCase("munin-node.localhost")]
+  public void HostName(string hostName)
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(() => options.HostName = hostName, Throws.Nothing);
+    Assert.That(options.HostName, Is.EqualTo(hostName));
+  }
+
+  [Test]
+  public void HostName_ArgumentNull()
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(
+      () => options.HostName = null!,
+      Throws.ArgumentNullException.With.Property(nameof(ArgumentNullException.ParamName)).EqualTo(nameof(options.HostName))
+    );
+  }
+
+  [Test]
+  public void HostName_ArgumentEmpty()
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(
+      () => options.HostName = "",
+      Throws.ArgumentException.With.Property(nameof(ArgumentException.ParamName)).EqualTo(nameof(options.HostName))
+    );
+  }
+
+  [Test]
+  public void UseAnyAddress()
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(
+      () => Assert.That(options.UseAnyAddress(), Is.SameAs(options)),
+      Throws.Nothing
+    );
+    Assert.That(
+      options.Address,
+      Is.SameAs(IPAddress.Any).Or.SameAs(IPAddress.IPv6Any)
+    );
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ValidPorts))]
+  public void UseAnyAddress_WithPort(int port)
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(
+      () => Assert.That(options.UseAnyAddress(port), Is.SameAs(options)),
+      Throws.Nothing
+    );
+    Assert.That(
+      options.Address,
+      Is.SameAs(IPAddress.Any).Or.SameAs(IPAddress.IPv6Any)
+    );
+    Assert.That(
+      options.Port,
+      Is.EqualTo(port)
+    );
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_InvalidPorts))]
+  public void UseAnyAddress_WithPort_InvalidPort(int port)
+  {
+    var initialAddress = IPAddress.Parse("192.0.2.0");
+    var options = new MuninNodeOptions() {
+      Address = initialAddress
+    };
+
+    Assert.That(
+      () => options.UseAnyAddress(port: port),
+      Throws
+        .TypeOf<ArgumentOutOfRangeException>()
+        .With
+        .Property(nameof(ArgumentOutOfRangeException.ParamName))
+        .EqualTo("port")
+        .And
+        .Property(nameof(ArgumentOutOfRangeException.ActualValue))
+        .EqualTo(port)
+    );
+
+    Assert.That(options.Address, Is.SameAs(initialAddress));
+  }
+
+  [Test]
+  public void UseLoopbackAddress()
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(
+      () => Assert.That(options.UseLoopbackAddress(), Is.SameAs(options)),
+      Throws.Nothing
+    );
+    Assert.That(
+      options.Address,
+      Is.SameAs(IPAddress.Loopback).Or.SameAs(IPAddress.IPv6Loopback)
+    );
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ValidPorts))]
+  public void UseLoopbackAddress_WithPort(int port)
+  {
+    var options = new MuninNodeOptions();
+
+    Assert.That(
+      () => Assert.That(options.UseLoopbackAddress(port), Is.SameAs(options)),
+      Throws.Nothing
+    );
+    Assert.That(
+      options.Address,
+      Is.SameAs(IPAddress.Loopback).Or.SameAs(IPAddress.IPv6Loopback)
+    );
+    Assert.That(
+      options.Port,
+      Is.EqualTo(port)
+    );
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_InvalidPorts))]
+  public void UseLoopbackAddress_WithPort_InvalidPort(int port)
+  {
+    var initialAddress = IPAddress.Parse("192.0.2.0");
+    var options = new MuninNodeOptions() {
+      Address = initialAddress
+    };
+
+    Assert.That(
+      () => options.UseLoopbackAddress(port: port),
+      Throws
+        .TypeOf<ArgumentOutOfRangeException>()
+        .With
+        .Property(nameof(ArgumentOutOfRangeException.ParamName))
+        .EqualTo("port")
+        .And
+        .Property(nameof(ArgumentOutOfRangeException.ActualValue))
+        .EqualTo(port)
+    );
+
+    Assert.That(options.Address, Is.SameAs(initialAddress));
+  }
+
+  [Test]
+  public void AllowFrom()
+  {
+    var options = new MuninNodeOptions() {
+      AccessRule = null
+    };
+    var addresses = new[] {
+      IPAddress.Parse("192.0.2.0"),
+      IPAddress.Parse("192.0.2.1"),
+      IPAddress.Parse("192.0.2.2")
+    };
+
+    Assert.That(
+      () => Assert.That(options.AllowFrom(addresses: addresses), Is.SameAs(options)),
+      Throws.Nothing
+    );
+
+    Assert.That(options.AccessRule, Is.Not.Null);
+
+    Assert.Multiple(() => {
+      foreach (var port in new[] { 0, 1, 6553 }) {
+        foreach (var address in addresses) {
+          var endPoint = new IPEndPoint(address, port);
+
+          Assert.That(options.AccessRule.IsAcceptable(endPoint), Is.True);
+        }
+
+        foreach (var address in new[] { IPAddress.Loopback, IPAddress.IPv6Loopback }) {
+          var endPoint = new IPEndPoint(address, port);
+
+          Assert.That(options.AccessRule.IsAcceptable(endPoint), Is.False);
+        }
+      }
+    });
+  }
+
+  [Test]
+  public void AllowFrom_ShouldConsiderIPv4MappedIPv6Address([Values] bool shouldConsiderIPv4MappedIPv6Address)
+  {
+    var options = new MuninNodeOptions() {
+      AccessRule = null
+    };
+    var ipv4Address = IPAddress.Parse("192.0.2.0");
+    var addresses = new[] {
+      ipv4Address,
+    };
+
+    Assert.That(
+      () => Assert.That(
+        options.AllowFrom(
+          addresses: addresses,
+          shouldConsiderIPv4MappedIPv6Address: shouldConsiderIPv4MappedIPv6Address
+        ),
+        Is.SameAs(options)
+      ),
+      Throws.Nothing
+    );
+
+    Assert.That(options.AccessRule, Is.Not.Null);
+
+    Assert.That(
+      options.AccessRule.IsAcceptable(new IPEndPoint(ipv4Address, 0)),
+      Is.True
+    );
+    Assert.That(
+      options.AccessRule.IsAcceptable(new IPEndPoint(ipv4Address.MapToIPv6(), 0)),
+      Is.EqualTo(shouldConsiderIPv4MappedIPv6Address)
+    );
+  }
+
+  [Test]
+  public void AllowFrom_ArgumentNull()
+  {
+    var options = new MuninNodeOptions() {
+      AccessRule = null
+    };
+
+    Assert.That(
+      () => Assert.That(options.AllowFrom(addresses: null!), Is.SameAs(options)),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("addresses")
+    );
+
+    Assert.That(options.AccessRule, Is.Null);
+  }
+
+  [Test]
+  public void AllowFromLoopbackOnly()
+  {
+    var options = new MuninNodeOptions() {
+      AccessRule = null
+    };
+
+    Assert.That(
+      () => Assert.That(options.AllowFromLoopbackOnly(), Is.SameAs(options)),
+      Throws.Nothing
+    );
+
+    Assert.That(options.AccessRule, Is.Not.Null);
+
+    Assert.That(options.AccessRule.IsAcceptable(new IPEndPoint(IPAddress.Loopback, 0)), Is.True);
+    Assert.That(options.AccessRule.IsAcceptable(new IPEndPoint(IPAddress.Loopback.MapToIPv6(), 0)), Is.True);
+    Assert.That(options.AccessRule.IsAcceptable(new IPEndPoint(IPAddress.IPv6Loopback, 0)), Is.True);
+    Assert.That(options.AccessRule.IsAcceptable(new IPEndPoint(IPAddress.Any, 0)), Is.False);
+    Assert.That(options.AccessRule.IsAcceptable(new IPEndPoint(IPAddress.IPv6Any, 0)), Is.False);
+  }
+}

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.Accept.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.Accept.cs
@@ -36,7 +36,7 @@ public partial class NodeBaseTests {
       cts.Token
     );
 
-    using var client = CreateClient((IPEndPoint)node.LocalEndPoint, out var writer, out var reader);
+    using var client = CreateClient((IPEndPoint)node.EndPoint, out var writer, out var reader);
 
     try {
       reader.ReadLine(); // banner
@@ -62,7 +62,7 @@ public partial class NodeBaseTests {
 
     var taskAccept = Task.Run(async () => await node.AcceptSingleSessionAsync());
 
-    using var client = CreateClient((IPEndPoint)node.LocalEndPoint, out var writer, out var reader);
+    using var client = CreateClient((IPEndPoint)node.EndPoint, out var writer, out var reader);
 
     var banner = reader.ReadLine();
 
@@ -107,7 +107,7 @@ public partial class NodeBaseTests {
 
     var taskAccept = Task.Run(async () => await node.AcceptSingleSessionAsync());
 
-    using var client = CreateClient((IPEndPoint)node.LocalEndPoint, out _, out _);
+    using var client = CreateClient((IPEndPoint)node.EndPoint, out _, out _);
 
     client.Close();
 
@@ -123,7 +123,7 @@ public partial class NodeBaseTests {
 
     var taskAccept = Task.Run(async () => await node.AcceptSingleSessionAsync());
 
-    using var client = CreateClient((IPEndPoint)node.LocalEndPoint, out _, out var reader);
+    using var client = CreateClient((IPEndPoint)node.EndPoint, out _, out var reader);
 
     reader.ReadLine(); // read banner
 
@@ -246,7 +246,7 @@ public partial class NodeBaseTests {
     Assert.That(plugin.StartedSessionIds.Count, Is.EqualTo(0), nameof(plugin.StartedSessionIds));
     Assert.That(plugin.ClosedSessionIds.Count, Is.EqualTo(0), nameof(plugin.ClosedSessionIds));
 
-    using var client = CreateClient((IPEndPoint)node.LocalEndPoint, out var writer, out var reader);
+    using var client = CreateClient((IPEndPoint)node.EndPoint, out var writer, out var reader);
 
     var banner = reader.ReadLine();
 
@@ -294,7 +294,7 @@ public partial class NodeBaseTests {
 
     var taskAccept = Task.Run(async () => await node.AcceptAsync(throwIfCancellationRequested, cts.Token));
 
-    using var client0 = CreateClient((IPEndPoint)node.LocalEndPoint, out var writer0, out var reader0);
+    using var client0 = CreateClient((IPEndPoint)node.EndPoint, out var writer0, out var reader0);
 
     reader0.ReadLine();
     writer0.WriteLine(".");
@@ -302,7 +302,7 @@ public partial class NodeBaseTests {
 
     Assert.That(taskAccept.Wait(TimeSpan.FromSeconds(1.0)), Is.False, "task must not be completed");
 
-    using var client1 = CreateClient((IPEndPoint)node.LocalEndPoint, out var writer1, out var reader1);
+    using var client1 = CreateClient((IPEndPoint)node.EndPoint, out var writer1, out var reader1);
 
     reader1.ReadLine();
     writer1.WriteLine(".");

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
@@ -91,8 +91,9 @@ public partial class NodeBaseTests {
 
     Assert.That(node.Dispose, Throws.Nothing, "Dispose() #1");
 
-    Assert.That(() => _ = node.LocalEndPoint, Throws.TypeOf<ObjectDisposedException>());
+    Assert.That(() => _ = node.EndPoint, Throws.TypeOf<ObjectDisposedException>());
 #pragma warning disable CS0618
+    Assert.That(() => _ = node.LocalEndPoint, Throws.TypeOf<ObjectDisposedException>());
     Assert.That(node.Start, Throws.TypeOf<ObjectDisposedException>());
 #pragma warning restore CS0618
     Assert.That(() => node.StartAsync(default), Throws.TypeOf<ObjectDisposedException>());
@@ -111,8 +112,9 @@ public partial class NodeBaseTests {
 
     Assert.That(node.DisposeAsync, Throws.Nothing, "DisposeAsync() #1");
 
-    Assert.That(() => _ = node.LocalEndPoint, Throws.TypeOf<ObjectDisposedException>());
+    Assert.That(() => _ = node.EndPoint, Throws.TypeOf<ObjectDisposedException>());
 #pragma warning disable CS0618
+    Assert.That(() => _ = node.LocalEndPoint, Throws.TypeOf<ObjectDisposedException>());
     Assert.That(node.Start, Throws.TypeOf<ObjectDisposedException>());
 #pragma warning restore CS0618
     Assert.That(() => node.StartAsync(default), Throws.TypeOf<ObjectDisposedException>());
@@ -129,14 +131,20 @@ public partial class NodeBaseTests {
   {
     await using var node = CreateNode();
 
+    Assert.That(() => _ = node.EndPoint, Throws.InvalidOperationException, $"{nameof(node.EndPoint)} before start");
+#pragma warning disable CS0618
     Assert.That(() => _ = node.LocalEndPoint, Throws.InvalidOperationException, $"{nameof(node.LocalEndPoint)} before start");
+#pragma warning restore CS0618
 
 #pragma warning disable CS0618
     Assert.DoesNotThrow(node.Start);
     Assert.Throws<InvalidOperationException>(node.Start, "already started");
 #pragma warning restore CS0618
 
+    Assert.That(() => _ = node.EndPoint, Throws.Nothing, $"{nameof(node.EndPoint)} after start");
+#pragma warning disable CS0618
     Assert.That(() => _ = node.LocalEndPoint, Throws.Nothing, $"{nameof(node.LocalEndPoint)} after start");
+#pragma warning restore CS0618
   }
 
   [Test]
@@ -144,11 +152,17 @@ public partial class NodeBaseTests {
   {
     await using var node = CreateNode();
 
+    Assert.That(() => _ = node.EndPoint, Throws.InvalidOperationException, $"{nameof(node.EndPoint)} before start");
+#pragma warning disable CS0618
     Assert.That(() => _ = node.LocalEndPoint, Throws.InvalidOperationException, $"{nameof(node.LocalEndPoint)} before start");
+#pragma warning restore CS0618
 
     Assert.That(async () => await node.StartAsync(default), Throws.Nothing);
     Assert.That(async () => await node.StartAsync(default), Throws.InvalidOperationException, "already started");
 
+    Assert.That(() => _ = node.EndPoint, Throws.Nothing, $"{nameof(node.EndPoint)} after start");
+#pragma warning disable CS0618
     Assert.That(() => _ = node.LocalEndPoint, Throws.Nothing, $"{nameof(node.LocalEndPoint)} after start");
+#pragma warning restore CS0618
   }
 }

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/AggregatePluginProvider.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/AggregatePluginProvider.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 namespace Smdn.Net.MuninPlugin;
 
 [TestFixture]
-public class ReadOnlyPluginProviderCollectionTests {
+public class AggregatePluginProviderTests {
   private class PseudoPlugin(string name) : IPlugin {
     public string Name { get; } = name;
     public IPluginGraphAttributes GraphAttributes => throw new NotImplementedException();
@@ -44,7 +44,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   [Test]
   public void Plugins_ZeroPluginProviders()
   {
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([]);
+    var pluginProviderCollections = new AggregatePluginProvider([]);
 
     Assert.That(pluginProviderCollections.Count, Is.Zero);
     Assert.That(pluginProviderCollections.Plugins.Count, Is.Zero);
@@ -53,7 +53,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   [Test]
   public void Plugins_SinglePluginProvider_ZeroPlugins()
   {
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+    var pluginProviderCollections = new AggregatePluginProvider([
       new PseudoPluginProvider([])
     ]);
 
@@ -64,7 +64,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   [Test]
   public void Plugins_SinglePluginProvider_SinglePlugin()
   {
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+    var pluginProviderCollections = new AggregatePluginProvider([
       new PseudoPluginProvider([
         new PseudoPlugin("#1")
       ])
@@ -78,7 +78,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   [Test]
   public void Plugins_SinglePluginProvider_MultiplePlugins()
   {
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+    var pluginProviderCollections = new AggregatePluginProvider([
       new PseudoPluginProvider([
         new PseudoPlugin("#1"),
         new PseudoPlugin("#2"),
@@ -93,7 +93,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   [Test]
   public void Plugins_MultiplePluginProviders_ZeroPlugins()
   {
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+    var pluginProviderCollections = new AggregatePluginProvider([
       new PseudoPluginProvider([]),
       new PseudoPluginProvider([])
     ]);
@@ -105,7 +105,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   [Test]
   public void Plugins_MultiplePluginProviders_SinglePlugin()
   {
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+    var pluginProviderCollections = new AggregatePluginProvider([
       new PseudoPluginProvider([
         new PseudoPlugin("#1")
       ]),
@@ -120,7 +120,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   [Test]
   public void Plugins_MultiplePluginProviders_MultiplePlugins()
   {
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+    var pluginProviderCollections = new AggregatePluginProvider([
       new PseudoPluginProvider([
         new PseudoPlugin("#1"),
       ]),
@@ -140,7 +140,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   {
     var provider1 = new PseudoPluginProvider([]);
     var provider2 = new PseudoPluginProvider([]);
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+    var pluginProviderCollections = new AggregatePluginProvider([
       provider1,
       provider2,
     ]);
@@ -164,7 +164,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   {
     var provider1 = new PseudoPluginProvider([]);
     var provider2 = new PseudoPluginProvider([]);
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+    var pluginProviderCollections = new AggregatePluginProvider([
       provider1,
       provider2,
     ]);
@@ -188,7 +188,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   {
     var provider1 = new PseudoPluginProvider([]);
     var provider2 = new PseudoPluginProvider([]);
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+    var pluginProviderCollections = new AggregatePluginProvider([
       provider1,
       provider2,
     ]);
@@ -214,7 +214,7 @@ public class ReadOnlyPluginProviderCollectionTests {
   {
     var provider1 = new PseudoPluginProvider([]);
     var provider2 = new PseudoPluginProvider([]);
-    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+    var pluginProviderCollections = new AggregatePluginProvider([
       provider1,
       provider2,
     ]);

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/ReadOnlyPluginProviderCollection.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/ReadOnlyPluginProviderCollection.cs
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace Smdn.Net.MuninPlugin;
+
+[TestFixture]
+public class ReadOnlyPluginProviderCollectionTests {
+  private class PseudoPlugin(string name) : IPlugin {
+    public string Name { get; } = name;
+    public IPluginGraphAttributes GraphAttributes => throw new NotImplementedException();
+    public IPluginDataSource DataSource => throw new NotImplementedException();
+    public INodeSessionCallback? SessionCallback => null;
+  }
+
+  private class PseudoPluginProvider(IReadOnlyCollection<IPlugin> plugins) : IPluginProvider, INodeSessionCallback {
+    public IReadOnlyCollection<IPlugin> Plugins => plugins;
+    public INodeSessionCallback? SessionCallback => this;
+
+    public int NumberOfInvocationOfReportSessionStartedAsync = 0;
+    public int NumberOfInvocationOfReportSessionClosedAsync = 0;
+
+    public ValueTask ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken)
+    {
+      NumberOfInvocationOfReportSessionStartedAsync++;
+
+      return default;
+    }
+
+    public ValueTask ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken)
+    {
+      NumberOfInvocationOfReportSessionClosedAsync++;
+
+      return default;
+    }
+  }
+
+  [Test]
+  public void Plugins_ZeroPluginProviders()
+  {
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([]);
+
+    Assert.That(pluginProviderCollections.Count, Is.Zero);
+    Assert.That(pluginProviderCollections.Plugins.Count, Is.Zero);
+  }
+
+  [Test]
+  public void Plugins_SinglePluginProvider_ZeroPlugins()
+  {
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+      new PseudoPluginProvider([])
+    ]);
+
+    Assert.That(pluginProviderCollections.Count, Is.EqualTo(1));
+    Assert.That(pluginProviderCollections.Plugins.Count, Is.Zero);
+  }
+
+  [Test]
+  public void Plugins_SinglePluginProvider_SinglePlugin()
+  {
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+      new PseudoPluginProvider([
+        new PseudoPlugin("#1")
+      ])
+    ]);
+
+    Assert.That(pluginProviderCollections.Count, Is.EqualTo(1));
+    Assert.That(pluginProviderCollections.Plugins.Count, Is.EqualTo(1));
+    Assert.That(pluginProviderCollections.Plugins.Select(static p => p.Name), Is.EquivalentTo(["#1"]));
+  }
+
+  [Test]
+  public void Plugins_SinglePluginProvider_MultiplePlugins()
+  {
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+      new PseudoPluginProvider([
+        new PseudoPlugin("#1"),
+        new PseudoPlugin("#2"),
+      ])
+    ]);
+
+    Assert.That(pluginProviderCollections.Count, Is.EqualTo(1));
+    Assert.That(pluginProviderCollections.Plugins.Count, Is.EqualTo(2));
+    Assert.That(pluginProviderCollections.Plugins.Select(static p => p.Name), Is.EquivalentTo(["#1", "#2"]));
+  }
+
+  [Test]
+  public void Plugins_MultiplePluginProviders_ZeroPlugins()
+  {
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+      new PseudoPluginProvider([]),
+      new PseudoPluginProvider([])
+    ]);
+
+    Assert.That(pluginProviderCollections.Count, Is.EqualTo(2));
+    Assert.That(pluginProviderCollections.Plugins.Count, Is.Zero);
+  }
+
+  [Test]
+  public void Plugins_MultiplePluginProviders_SinglePlugin()
+  {
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+      new PseudoPluginProvider([
+        new PseudoPlugin("#1")
+      ]),
+      new PseudoPluginProvider([])
+    ]);
+
+    Assert.That(pluginProviderCollections.Count, Is.EqualTo(2));
+    Assert.That(pluginProviderCollections.Plugins.Count, Is.EqualTo(1));
+    Assert.That(pluginProviderCollections.Plugins.Select(static p => p.Name), Is.EquivalentTo(["#1"]));
+  }
+
+  [Test]
+  public void Plugins_MultiplePluginProviders_MultiplePlugins()
+  {
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+      new PseudoPluginProvider([
+        new PseudoPlugin("#1"),
+      ]),
+      new PseudoPluginProvider([
+        new PseudoPlugin("#2"),
+        new PseudoPlugin("#3"),
+      ])
+    ]);
+
+    Assert.That(pluginProviderCollections.Count, Is.EqualTo(2));
+    Assert.That(pluginProviderCollections.Plugins.Count, Is.EqualTo(3));
+    Assert.That(pluginProviderCollections.Plugins.Select(static p => p.Name), Is.EquivalentTo(["#1", "#2", "#3"]));
+  }
+
+  [Test]
+  public void INodeSessionCallback_ReportSessionStartedAsync()
+  {
+    var provider1 = new PseudoPluginProvider([]);
+    var provider2 = new PseudoPluginProvider([]);
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+      provider1,
+      provider2,
+    ]);
+
+    INodeSessionCallback sessionCallback = pluginProviderCollections;
+
+    Assert.That(
+      async () => await sessionCallback.ReportSessionStartedAsync(string.Empty, default),
+      Throws.Nothing
+    );
+
+    Assert.That(provider1.NumberOfInvocationOfReportSessionStartedAsync, Is.EqualTo(1));
+    Assert.That(provider1.NumberOfInvocationOfReportSessionClosedAsync, Is.Zero);
+
+    Assert.That(provider2.NumberOfInvocationOfReportSessionStartedAsync, Is.EqualTo(1));
+    Assert.That(provider2.NumberOfInvocationOfReportSessionClosedAsync, Is.Zero);
+  }
+
+  [Test]
+  public void INodeSessionCallback_ReportSessionClosedAsync()
+  {
+    var provider1 = new PseudoPluginProvider([]);
+    var provider2 = new PseudoPluginProvider([]);
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+      provider1,
+      provider2,
+    ]);
+
+    INodeSessionCallback sessionCallback = pluginProviderCollections;
+
+    Assert.That(
+      async () => await sessionCallback.ReportSessionClosedAsync(string.Empty, default),
+      Throws.Nothing
+    );
+
+    Assert.That(provider1.NumberOfInvocationOfReportSessionStartedAsync, Is.Zero);
+    Assert.That(provider1.NumberOfInvocationOfReportSessionClosedAsync, Is.EqualTo(1));
+
+    Assert.That(provider2.NumberOfInvocationOfReportSessionStartedAsync, Is.Zero);
+    Assert.That(provider2.NumberOfInvocationOfReportSessionClosedAsync, Is.EqualTo(1));
+  }
+
+  [Test]
+  public void INodeSessionCallback_ReportSessionStartedAsync_CancellationRequested()
+  {
+    var provider1 = new PseudoPluginProvider([]);
+    var provider2 = new PseudoPluginProvider([]);
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+      provider1,
+      provider2,
+    ]);
+
+    INodeSessionCallback sessionCallback = pluginProviderCollections;
+
+    using var cts = new CancellationTokenSource(0);
+
+    Assert.That(
+      async () => await sessionCallback.ReportSessionStartedAsync(string.Empty, cts.Token),
+      Throws.InstanceOf<OperationCanceledException>()
+    );
+
+    Assert.That(provider1.NumberOfInvocationOfReportSessionStartedAsync, Is.Zero);
+    Assert.That(provider1.NumberOfInvocationOfReportSessionClosedAsync, Is.Zero);
+
+    Assert.That(provider2.NumberOfInvocationOfReportSessionStartedAsync, Is.Zero);
+    Assert.That(provider2.NumberOfInvocationOfReportSessionClosedAsync, Is.Zero);
+  }
+
+  [Test]
+  public void INodeSessionCallback_ReportSessionClosedAsync_CancellationRequested()
+  {
+    var provider1 = new PseudoPluginProvider([]);
+    var provider2 = new PseudoPluginProvider([]);
+    var pluginProviderCollections = new ReadOnlyPluginProviderCollection([
+      provider1,
+      provider2,
+    ]);
+
+    INodeSessionCallback sessionCallback = pluginProviderCollections;
+
+    using var cts = new CancellationTokenSource(0);
+
+    Assert.That(
+      async () => await sessionCallback.ReportSessionClosedAsync(string.Empty, cts.Token),
+      Throws.InstanceOf<OperationCanceledException>()
+    );
+
+    Assert.That(provider1.NumberOfInvocationOfReportSessionStartedAsync, Is.Zero);
+    Assert.That(provider1.NumberOfInvocationOfReportSessionClosedAsync, Is.Zero);
+
+    Assert.That(provider2.NumberOfInvocationOfReportSessionStartedAsync, Is.Zero);
+    Assert.That(provider2.NumberOfInvocationOfReportSessionClosedAsync, Is.Zero);
+  }
+}


### PR DESCRIPTION
### Description
Add support for building Munin-Node using the DI design pattern.

This PR adds a new namespace `Smdn.Net.MuninNode.DependencyInjection`.
Add extension methods to this namespace for building the `Munin-Node`s, using the DI design pattern and the Fluent API.

In this PR, the following interfaces and classes will be added:

- `IMuninServiceBuilder`: An interface for building and registering Munin services (`IMuninNodeBuilder`) to `IServiceCollection`.
- `IMuninNodeBuilder`: An interface for building the Munin Nodes. It is registered with the `IServiceCollection`.
- `DefaultMuninNode`: An internal and extended class of `NodeBase` that is built by `IMuninNodeBuilder` and supports dependency injection by using `IServiceProvider`.
- `MuninNodeOptions`: A class for setting and holding options for configuring Munin Node addresses, ports, hostnames, etc.

An example of using the API to be added is as follows:

```cs
var services = new ServiceCollection();

services
  .AddMunin(
    muninBuilder => muninBuilder
      .AddNode((MuninNodeOptions options) => {
        options.HostName = "munin-node.localhost";
        options.UseAnyAddress(port: 12345);
        options.AllowFrom([IPAddress.Parse("192.168.2.0"), IPAddress.Loopback]);
      })
      .AddPlugin(PluginFactory.CreatePlugin(...))
      .AddPlugin(serviceProvider => PluginFactory.CreatePlugin(...))
      .UseSessionCallback((INodeSessionCallback)new(...))
      .UseListenerFactory((IMuninNodeListenerFactory)new(...))
  );
```

### Considerations
It is noted that the implementation to be added with this PR is based on ideas proposed in the discussion #11 and PR #12.

PR #12 cannot be merged as is, and its author seems no longer willing to update it.
Therefore, this PR will close #12.
