### PR TITLE
Add APIs to support .NET generic host

### DIFF
--- a/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting.csproj
+++ b/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting.csproj
@@ -1,0 +1,51 @@
+<!--
+SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
+    <!--<PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>-->
+    <RootNamespace/> <!-- empty the root namespace so that the namespace is determined only by the directory name, for code style rule IDE0030 -->
+    <Nullable>enable</Nullable>
+    <NoWarn>CS1591;$(NoWarn)</NoWarn> <!-- CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member' -->
+  </PropertyGroup>
+
+  <PropertyGroup Label="assembly attributes">
+    <Description>
+<![CDATA[A .NET implementation of [Munin-Node](https://guide.munin-monitoring.org/en/latest/node/index.html) for [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host).
+
+This library provides APIs to run Munin-Node as a background service running on a .NET Generic Host.
+
+This library mainly provides a `MuninNodeBackgroundService` class derived from `BackgroundService`, and extension methods to register the Munin-Node service to the `ServiceCollection`.
+
+This library uses [Smdn.Net.MuninNode](https://www.nuget.org/packages/Smdn.Net.MuninNode) and the API is provided as an extension to `Smdn.Net.MuninNode`.
+]]>
+    </Description>
+    <CopyrightYear>2025</CopyrightYear>
+  </PropertyGroup>
+
+  <PropertyGroup Label="package properties">
+    <PackageTags>Munin,Munin-Node,Munin-Plugin,hosting,generic-host,dependency-injection</PackageTags>
+    <GenerateNupkgReadmeFileDependsOnTargets>$(GenerateNupkgReadmeFileDependsOnTargets);GenerateReadmeFileContent</GenerateNupkgReadmeFileDependsOnTargets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <!-- <ProjectOrPackageReference ReferencePackageVersion="[2.2.0,4.0.0)" Include="..\Smdn.Net.MuninNode\Smdn.Net.MuninNode.csproj" /> -->
+    <ProjectReference Include="..\Smdn.Net.MuninNode\Smdn.Net.MuninNode.csproj" />
+  </ItemGroup>
+
+  <Target Name="GenerateReadmeFileContent">
+    <PropertyGroup>
+      <PackageReadmeFileContent><![CDATA[# $(PackageId) $(PackageVersion)
+$(Description)
+
+## Contributing
+This project welcomes contributions, feedbacks and suggestions. You can contribute to this project by submitting [Issues]($(RepositoryUrl)/issues/new/choose) or [Pull Requests]($(RepositoryUrl)/pulls/) on the [GitHub repository]($(RepositoryUrl)).
+]]></PackageReadmeFileContent>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/IServiceCollectionExtensions.cs
+++ b/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/IServiceCollectionExtensions.cs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Smdn.Net.MuninNode.DependencyInjection;
+
+namespace Smdn.Net.MuninNode.Hosting;
+
+public static class IServiceCollectionExtensions {
+  /// <summary>
+  /// Add <see cref="MuninNodeBackgroundService"/>, which runs <c>Munin-Node</c> as an
+  /// <see cref="Microsoft.Extensions.Hosting.IHostedService"/>, to <see cref="IServiceCollection"/>.
+  /// </summary>
+  /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+  /// <param name="configureNode">
+  /// An <see cref="Action{MuninNodeOptions}"/> to setup <see cref="MuninNodeOptions"/> to
+  /// configure the <c>Munin-Node</c> to be built.
+  /// </param>
+  /// <param name="buildNode">
+  /// An <see cref="Action{IMuninServiceBuilder}"/> to build <c>Munin-Node</c> using with
+  /// the <see cref="IMuninServiceBuilder"/>.
+  /// </param>
+  /// <returns>The current <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="services"/> is <see langword="null"/>, or
+  /// <paramref name="configureNode"/> is <see langword="null"/>, or
+  /// <paramref name="buildNode"/> is <see langword="null"/>.
+  /// </exception>
+  public static IServiceCollection AddHostedMuninNodeService(
+    this IServiceCollection services,
+    Action<MuninNodeOptions> configureNode,
+    Action<IMuninNodeBuilder> buildNode
+  )
+  {
+    if (services is null)
+      throw new ArgumentNullException(nameof(services));
+    if (configureNode is null)
+      throw new ArgumentNullException(nameof(configureNode));
+    if (buildNode is null)
+      throw new ArgumentNullException(nameof(buildNode));
+
+    return services.AddMunin(
+      muninBuilder => {
+        var muninNodeBuilder = muninBuilder.AddNode(configureNode);
+
+        buildNode(muninNodeBuilder);
+
+        muninNodeBuilder.Services.AddHostedService<MuninNodeBackgroundService>();
+
+        // TODO: support keyed service
+#if false
+        var muninNodeBuilder = muninBuilder.AddKeyedNode(configureNode);
+
+        buildNode(muninNodeBuilder);
+
+        // these code does not work currently
+        // https://github.com/dotnet/runtime/issues/99085
+        muninNodeBuilder.Services.AddHostedService<MuninNodeBackgroundService>(
+          serviceKey: muninNodeBuilder.ServiceKey
+        );
+
+        muninNodeBuilder.Services.TryAddEnumerable(
+          ServiceDescriptor.KeyedSingleton<IHostedService, MuninNodeBackgroundService>(
+            serviceKey: muninNodeBuilder.ServiceKey
+          )
+        );
+#endif
+      }
+    );
+  }
+}

--- a/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/MuninNodeBackgroundService.cs
+++ b/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/MuninNodeBackgroundService.cs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+#pragma warning disable CA1848 // For improved performance, use the LoggerMessage delegates instead of calling 'LoggerExtensions.LogInformation(ILogger, string?, params object?[])'
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Smdn.Net.MuninNode.Hosting;
+
+public class MuninNodeBackgroundService : BackgroundService {
+  private IMuninNode node;
+  private readonly ILogger<MuninNodeBackgroundService>? logger;
+
+  /// <inheritdoc cref="IMuninNode.EndPoint"/>
+  public EndPoint EndPoint => (node ?? throw new ObjectDisposedException(GetType().FullName)).EndPoint;
+
+#if false
+  // TODO: support ServiceKey
+  // this code does not work currently
+  // https://github.com/dotnet/runtime/issues/99085
+  public MuninNodeBackgroundService(
+    [ServiceKey] string serviceKey,
+    IServiceProvider serviceProvider
+  )
+  {
+    this.node = serviceProvider.GetRequiredKeyedService<IMuninNode>(serviceKey);
+    this.logger = serviceProvider.GetService<ILoggerFactory>()?.CreateLogger<MuninNodeBackgroundService>();
+  }
+#endif
+
+  public MuninNodeBackgroundService(
+    IMuninNode node
+  )
+    : this(
+      node: node ?? throw new ArgumentNullException(nameof(node)),
+      logger: null
+    )
+  {
+  }
+
+  public MuninNodeBackgroundService(
+    IMuninNode node,
+    ILogger<MuninNodeBackgroundService>? logger
+  )
+  {
+    this.node = node ?? throw new ArgumentNullException(nameof(node));
+    this.logger = logger;
+  }
+
+  public override void Dispose()
+  {
+    if (node is IDisposable disposableNode)
+      disposableNode.Dispose();
+
+    node = null!;
+
+    base.Dispose();
+
+    GC.SuppressFinalize(this);
+  }
+
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    if (node is null)
+      throw new ObjectDisposedException(GetType().FullName);
+
+    logger?.LogInformation("Munin node '{HostName}' starting.", node.HostName);
+
+    await node.RunAsync(stoppingToken).ConfigureAwait(false);
+
+    logger?.LogInformation("Munin node '{HostName}' stopped.", node.HostName);
+
+    if (node is IDisposable disposableNode)
+      disposableNode.Dispose();
+  }
+}

--- a/tests/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting.Tests.csproj
+++ b/tests/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting.Tests.csproj
@@ -1,0 +1,20 @@
+<!--
+SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <RootNamespace/> <!-- empty the root namespace so that the namespace is determined only by the directory name, for code style rule IDE0130 -->
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet80)' == 'true' ">net8.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">$(TargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*"/>
+  </ItemGroup>
+</Project>

--- a/tests/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/IServiceCollectionExtensions.cs
+++ b/tests/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/IServiceCollectionExtensions.cs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using NUnit.Framework;
+
+namespace Smdn.Net.MuninNode.Hosting;
+
+[TestFixture]
+public class IServiceCollectionExtensionsTests {
+  [Test]
+  public void AddHostedMuninNodeService_ArgumentNull()
+  {
+    var services = new ServiceCollection();
+
+    Assert.That(
+      () => services.AddHostedMuninNodeService(
+        configureNode: null!,
+        buildNode: builder => { }
+      ),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("configureNode")
+    );
+
+    Assert.That(
+      () => services.AddHostedMuninNodeService(
+        configureNode: options => { },
+        buildNode: null!
+      ),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("buildNode")
+    );
+  }
+
+  [Test]
+  public void AddHostedMuninNodeService()
+  {
+    var services = new ServiceCollection();
+
+    services.AddHostedMuninNodeService(
+      configureNode: options => { },
+      buildNode: builder => { }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    var muninNodeService = serviceProvider.GetRequiredService<IHostedService>();
+
+    Assert.That(muninNodeService, Is.TypeOf<MuninNodeBackgroundService>());
+  }
+}

--- a/tests/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/MuninNodeBackgroundService.cs
+++ b/tests/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/MuninNodeBackgroundService.cs
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using NUnit.Framework;
+
+namespace Smdn.Net.MuninNode.Hosting;
+
+[TestFixture]
+public class MuninNodeBackgroundServiceTests {
+  [Test]
+  public void Dispose()
+  {
+    var services = new ServiceCollection();
+
+    services.AddHostedMuninNodeService(
+      configureNode: options => { },
+      buildNode: builder => { }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    using var muninNodeService = (MuninNodeBackgroundService)serviceProvider.GetRequiredService<IHostedService>();
+
+    Assert.That(
+      muninNodeService.Dispose,
+      Throws.Nothing
+    );
+    Assert.That(
+      muninNodeService.Dispose,
+      Throws.Nothing,
+      "dispose again"
+    );
+
+    Assert.That(
+      () => _ = muninNodeService.EndPoint,
+      Throws.TypeOf<ObjectDisposedException>()
+    );
+    Assert.That(
+      async () => await muninNodeService.StartAsync(default),
+      Throws.TypeOf<ObjectDisposedException>()
+    );
+  }
+
+  [Test]
+  [CancelAfter(5000)]
+  public async Task ExecuteAsync(CancellationToken cancellationToken)
+  {
+    const string HostName = "munin-node.localhost";
+    var services = new ServiceCollection();
+
+    services.AddHostedMuninNodeService(
+      configureNode: options => {
+        options.HostName = HostName;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+          options.UseLoopbackAddress(port: 0);
+        else
+          options.UseAnyAddress(port: 0);
+      },
+      buildNode: builder => { }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+    using var muninNodeService = (MuninNodeBackgroundService)serviceProvider.GetRequiredService<IHostedService>();
+
+    // start service
+    await muninNodeService.StartAsync(cancellationToken);
+
+    Assert.That(muninNodeService.EndPoint, Is.Not.Null);
+
+    var ipEndPoint = muninNodeService.EndPoint as IPEndPoint;
+
+    Assert.That(ipEndPoint, Is.Not.Null);
+    Assert.That(ipEndPoint.Port, Is.Not.Zero);
+
+    // connect to node
+    Assert.That(
+      async () => await ConnectToNodeAsync(ipEndPoint, HostName, cancellationToken),
+      Throws.Nothing
+    );
+
+    // stop service
+    await muninNodeService.StopAsync(cancellationToken);
+
+    // attempt to connect to stoppted node
+    using var ctsTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+    using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ctsTimeout.Token);
+
+    Assert.That(
+      async () => await ConnectToNodeAsync(ipEndPoint, HostName, cts.Token),
+      Throws.TypeOf<SocketException>().Or.InstanceOf<OperationCanceledException>()
+    );
+
+    static async Task ConnectToNodeAsync(
+      IPEndPoint endPoint,
+      string expectedBannerHostName,
+      CancellationToken cancellationToken
+    )
+    {
+      using var client = new TcpClient();
+
+      await client.ConnectAsync(endPoint);
+
+      using var reader = new StreamReader(
+        stream: client.GetStream(),
+        leaveOpen: false
+      );
+
+      Assert.That(
+        await reader.ReadLineAsync(cancellationToken),
+        Contains.Substring(expectedBannerHostName),
+        "banner response"
+      );
+
+      client.Close();
+    }
+  }
+}


### PR DESCRIPTION
### Description
Add support for building Munin-Node hosted service integrated with the .NET generic host.

This PR adds a new package/assembly/namespace `Smdn.Net.MuninNode.Hosting`.

In this PR, the following key API will be added:

- `AddHostedMuninNodeService()`: An extension method to `IServiceCollection` to register `MuninNodeBackgroundService`, as described below, which runs Munin-Node as a hosted/background service. The service to be registered is configured using the APIs from `Smdn.Net.MuninNode.DependencyInjection`. See #17 for detail.
- `MuninNodeBackgroundService`: The class extends `BackgroundService` to run Munin-Node as a hosted/background service. It holds a configured and built `IMuninNode`, and calls `IMuninNode.RunAsync` to start Munin-Node background tasks.

An example of using the API to be added is as follows:

```cs
var builder = Host.CreateApplicationBuilder(args);

builder.Services.AddHostedMuninNodeService(
  options => {
    options.HostName = "munin-node.localhost";
    options.UseAnyAddress(port: 12345);
    options.AllowFrom([IPAddress.Parse("192.168.2.0"), IPAddress.Loopback]);
  },
  nodeBuilder => nodeBuilder
    .AddPlugin(PluginFactory.CreatePlugin(...))
    .AddPlugin(serviceProvider => PluginFactory.CreatePlugin(...))
    .UseSessionCallback((INodeSessionCallback)new(...))
    .UseListenerFactory((IMuninNodeListenerFactory)new(...))
);
```

### Considerations
It is noted that the implementation to be added with this PR is based on ideas proposed in the discussion #11 and PR #12.

This PR is based on #17. It needs to be merged.
