### PR TITLE
Release main/Smdn.Net.MuninNode-2.2.0

### DIFF
--- a/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-net8.0.apilist.cs
@@ -1,12 +1,13 @@
-// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-2.1.0)
+// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-2.2.0)
 //   Name: Smdn.Net.MuninNode
-//   AssemblyVersion: 2.1.0.0
-//   InformationalVersion: 2.1.0+16b4425cbed9d9331220cdef22e4c3e669122124
+//   AssemblyVersion: 2.2.0.0
+//   InformationalVersion: 2.2.0+04e5ff38096e4d62b2c9bc5a716d8b2c5a6ad72d
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
-//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.Options, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.Fundamental.Exception, Version=3.0.0.0, Culture=neutral
 //     System.Collections, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
@@ -21,7 +22,9 @@
 #nullable enable annotations
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -30,6 +33,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Smdn.Net.MuninNode;
+using Smdn.Net.MuninNode.DependencyInjection;
+using Smdn.Net.MuninNode.Transport;
 using Smdn.Net.MuninPlugin;
 
 namespace Smdn.Net.MuninNode {
@@ -37,29 +42,67 @@ namespace Smdn.Net.MuninNode {
     bool IsAcceptable(IPEndPoint remoteEndPoint);
   }
 
+  public interface IMuninNode {
+    EndPoint EndPoint { get; }
+    string HostName { get; }
+
+    Task RunAsync(CancellationToken cancellationToken);
+  }
+
   public static class IAccessRuleServiceCollectionExtensions {
     public static IServiceCollection AddMuninNodeAccessRule(this IServiceCollection services, IAccessRule accessRule) {}
     public static IServiceCollection AddMuninNodeAccessRule(this IServiceCollection services, IReadOnlyList<IPAddress> addressListAllowFrom) {}
+    public static IServiceCollection AddMuninNodeAccessRule(this IServiceCollection services, IReadOnlyList<IPAddress> addressListAllowFrom, bool shouldConsiderIPv4MappedIPv6Address) {}
+    public static IServiceCollection AddMuninNodeLoopbackOnlyAccessRule(this IServiceCollection services) {}
   }
 
   public abstract class LocalNode : NodeBase {
     public static LocalNode Create(IPluginProvider pluginProvider, int port, string? hostName = null, IReadOnlyList<IPAddress>? addressListAllowFrom = null, IServiceProvider? serviceProvider = null) {}
     public static LocalNode Create(IReadOnlyCollection<IPlugin> plugins, int port, string? hostName = null, IReadOnlyList<IPAddress>? addressListAllowFrom = null, IServiceProvider? serviceProvider = null) {}
 
+    [Obsolete("Use a constructor overload that takes IMuninNodeListenerFactory as an argument.")]
     protected LocalNode(IAccessRule? accessRule, ILogger? logger = null) {}
+    protected LocalNode(IMuninNodeListenerFactory? listenerFactory, IAccessRule? accessRule, ILogger? logger) {}
 
+    [Obsolete("Use IMuninNodeListenerFactory and StartAsync instead.")]
     protected override Socket CreateServerSocket() {}
-    protected virtual EndPoint GetLocalEndPointToBind() {}
+  }
+
+  public sealed class MuninNodeOptions {
+    public const string DefaultHostName = "munin-node.localhost";
+    public const int DefaultPort = 4949;
+
+    public static IPAddress DefaultAddress { get; }
+
+    public MuninNodeOptions() {}
+
+    public IAccessRule? AccessRule { get; set; }
+    public IPAddress Address { get; set; }
+    public string HostName { get; set; }
+    public int Port { get; set; }
+
+    public MuninNodeOptions AllowFrom(IReadOnlyList<IPAddress> addresses, bool shouldConsiderIPv4MappedIPv6Address = true) {}
+    public MuninNodeOptions AllowFromLoopbackOnly() {}
+    public MuninNodeOptions UseAnyAddress() {}
+    public MuninNodeOptions UseAnyAddress(int port) {}
+    public MuninNodeOptions UseLoopbackAddress() {}
+    public MuninNodeOptions UseLoopbackAddress(int port) {}
   }
 
   public abstract class NodeBase :
     IAsyncDisposable,
-    IDisposable
+    IDisposable,
+    IMuninNode
   {
+    [Obsolete("Use a constructor overload that takes IMuninNodeListenerFactory as an argument.")]
     protected NodeBase(IAccessRule? accessRule, ILogger? logger) {}
+    protected NodeBase(IMuninNodeListenerFactory listenerFactory, IAccessRule? accessRule, ILogger? logger) {}
 
     public virtual Encoding Encoding { get; }
+    public EndPoint EndPoint { get; }
     public abstract string HostName { get; }
+    protected IMuninNodeListener? Listener { get; }
+    [Obsolete("Use EndPoint instead.")]
     public EndPoint LocalEndPoint { get; }
     protected ILogger? Logger { get; }
     public virtual Version NodeVersion { get; }
@@ -67,13 +110,87 @@ namespace Smdn.Net.MuninNode {
 
     public async ValueTask AcceptAsync(bool throwIfCancellationRequested, CancellationToken cancellationToken) {}
     public async ValueTask AcceptSingleSessionAsync(CancellationToken cancellationToken = default) {}
-    protected abstract Socket CreateServerSocket();
+    [Obsolete("Use IMuninNodeListenerFactory and StartAsync instead.")]
+    protected virtual Socket CreateServerSocket() {}
     protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
     protected virtual async ValueTask DisposeAsyncCore() {}
+    protected virtual EndPoint GetLocalEndPointToBind() {}
+    public Task RunAsync(CancellationToken cancellationToken) {}
+    [Obsolete("This method will be deprecated in the future.Use IMuninNodeListenerFactory and StartAsync instead.Make sure to override CreateServerSocket if you need to use this method.")]
     public void Start() {}
+    public ValueTask StartAsync(CancellationToken cancellationToken = default) {}
+    protected void ThrowIfDisposed() {}
     protected void ThrowIfPluginProviderIsNull() {}
+  }
+}
+
+namespace Smdn.Net.MuninNode.DependencyInjection {
+  public interface IMuninNodeBuilder {
+    string ServiceKey { get; }
+    IServiceCollection Services { get; }
+
+    IMuninNode Build(IServiceProvider serviceProvider);
+  }
+
+  public interface IMuninServiceBuilder {
+    IServiceCollection Services { get; }
+  }
+
+  public static class IMuninNodeBuilderExtensions {
+    public static IMuninNodeBuilder AddPlugin(this IMuninNodeBuilder builder, Func<IServiceProvider, IPlugin> buildPlugin) {}
+    public static IMuninNodeBuilder AddPlugin(this IMuninNodeBuilder builder, IPlugin plugin) {}
+    public static IMuninNodeBuilder UseListenerFactory(this IMuninNodeBuilder builder, Func<IServiceProvider, EndPoint, IMuninNode, CancellationToken, ValueTask<IMuninNodeListener>> createListenerAsyncFunc) {}
+    public static IMuninNodeBuilder UseListenerFactory(this IMuninNodeBuilder builder, Func<IServiceProvider, IMuninNodeListenerFactory> buildListenerFactory) {}
+    public static IMuninNodeBuilder UseListenerFactory(this IMuninNodeBuilder builder, IMuninNodeListenerFactory listenerFactory) {}
+    public static IMuninNodeBuilder UsePluginProvider(this IMuninNodeBuilder builder, Func<IServiceProvider, IPluginProvider> buildPluginProvider) {}
+    public static IMuninNodeBuilder UsePluginProvider(this IMuninNodeBuilder builder, IPluginProvider pluginProvider) {}
+    public static IMuninNodeBuilder UseSessionCallback(this IMuninNodeBuilder builder, Func<IServiceProvider, INodeSessionCallback> buildSessionCallback) {}
+    public static IMuninNodeBuilder UseSessionCallback(this IMuninNodeBuilder builder, Func<string, CancellationToken, ValueTask>? reportSessionStartedAsyncFunc, Func<string, CancellationToken, ValueTask>? reportSessionClosedAsyncFunc) {}
+    public static IMuninNodeBuilder UseSessionCallback(this IMuninNodeBuilder builder, INodeSessionCallback sessionCallback) {}
+  }
+
+  public static class IMuninServiceBuilderExtensions {
+    public static IMuninNodeBuilder AddNode(this IMuninServiceBuilder builder) {}
+    public static IMuninNodeBuilder AddNode(this IMuninServiceBuilder builder, Action<MuninNodeOptions> configure) {}
+  }
+
+  public static class IServiceCollectionExtensions {
+    public static IServiceCollection AddMunin(this IServiceCollection services, Action<IMuninServiceBuilder> configure) {}
+  }
+}
+
+namespace Smdn.Net.MuninNode.Transport {
+  public interface IMuninNodeClient :
+    IAsyncDisposable,
+    IDisposable
+  {
+    EndPoint? EndPoint { get; }
+
+    ValueTask DisconnectAsync(CancellationToken cancellationToken);
+    ValueTask<int> ReceiveAsync(IBufferWriter<byte> buffer, CancellationToken cancellationToken);
+    ValueTask SendAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken);
+  }
+
+  public interface IMuninNodeListener :
+    IAsyncDisposable,
+    IDisposable
+  {
+    EndPoint? EndPoint { get; }
+
+    ValueTask<IMuninNodeClient> AcceptAsync(CancellationToken cancellationToken);
+    ValueTask StartAsync(CancellationToken cancellationToken);
+  }
+
+  public interface IMuninNodeListenerFactory {
+    ValueTask<IMuninNodeListener> CreateAsync(EndPoint endPoint, IMuninNode node, CancellationToken cancellationToken);
+  }
+
+  public sealed class MuninNodeClientDisconnectedException : InvalidOperationException {
+    public MuninNodeClientDisconnectedException() {}
+    public MuninNodeClientDisconnectedException(string message) {}
+    public MuninNodeClientDisconnectedException(string message, Exception innerException) {}
   }
 }
 
@@ -123,6 +240,20 @@ namespace Smdn.Net.MuninPlugin {
     LineWidth2 = 102,
     LineWidth3 = 103,
     Stack = 2,
+  }
+
+  public sealed class AggregatePluginProvider :
+    ReadOnlyCollection<IPluginProvider>,
+    INodeSessionCallback,
+    IPluginProvider
+  {
+    public AggregatePluginProvider(IList<IPluginProvider> pluginProviders) {}
+
+    public IReadOnlyCollection<IPlugin> Plugins { get; }
+    INodeSessionCallback? IPluginProvider.SessionCallback { get; }
+
+    async ValueTask INodeSessionCallback.ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken) {}
+    async ValueTask INodeSessionCallback.ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken) {}
   }
 
   public class Plugin :

--- a/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-netstandard2.1.apilist.cs
@@ -1,12 +1,13 @@
-// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-2.1.0)
+// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-2.2.0)
 //   Name: Smdn.Net.MuninNode
-//   AssemblyVersion: 2.1.0.0
-//   InformationalVersion: 2.1.0+16b4425cbed9d9331220cdef22e4c3e669122124
+//   AssemblyVersion: 2.2.0.0
+//   InformationalVersion: 2.2.0+04e5ff38096e4d62b2c9bc5a716d8b2c5a6ad72d
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
-//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.Options, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.Fundamental.Encoding.Buffer, Version=3.0.0.0, Culture=neutral
 //     Smdn.Fundamental.Exception, Version=3.0.0.0, Culture=neutral
 //     System.IO.Pipelines, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
@@ -14,7 +15,9 @@
 #nullable enable annotations
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -23,6 +26,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Smdn.Net.MuninNode;
+using Smdn.Net.MuninNode.DependencyInjection;
+using Smdn.Net.MuninNode.Transport;
 using Smdn.Net.MuninPlugin;
 
 namespace Smdn.Net.MuninNode {
@@ -30,29 +35,67 @@ namespace Smdn.Net.MuninNode {
     bool IsAcceptable(IPEndPoint remoteEndPoint);
   }
 
+  public interface IMuninNode {
+    EndPoint EndPoint { get; }
+    string HostName { get; }
+
+    Task RunAsync(CancellationToken cancellationToken);
+  }
+
   public static class IAccessRuleServiceCollectionExtensions {
     public static IServiceCollection AddMuninNodeAccessRule(this IServiceCollection services, IAccessRule accessRule) {}
     public static IServiceCollection AddMuninNodeAccessRule(this IServiceCollection services, IReadOnlyList<IPAddress> addressListAllowFrom) {}
+    public static IServiceCollection AddMuninNodeAccessRule(this IServiceCollection services, IReadOnlyList<IPAddress> addressListAllowFrom, bool shouldConsiderIPv4MappedIPv6Address) {}
+    public static IServiceCollection AddMuninNodeLoopbackOnlyAccessRule(this IServiceCollection services) {}
   }
 
   public abstract class LocalNode : NodeBase {
     public static LocalNode Create(IPluginProvider pluginProvider, int port, string? hostName = null, IReadOnlyList<IPAddress>? addressListAllowFrom = null, IServiceProvider? serviceProvider = null) {}
     public static LocalNode Create(IReadOnlyCollection<IPlugin> plugins, int port, string? hostName = null, IReadOnlyList<IPAddress>? addressListAllowFrom = null, IServiceProvider? serviceProvider = null) {}
 
+    [Obsolete("Use a constructor overload that takes IMuninNodeListenerFactory as an argument.")]
     protected LocalNode(IAccessRule? accessRule, ILogger? logger = null) {}
+    protected LocalNode(IMuninNodeListenerFactory? listenerFactory, IAccessRule? accessRule, ILogger? logger) {}
 
+    [Obsolete("Use IMuninNodeListenerFactory and StartAsync instead.")]
     protected override Socket CreateServerSocket() {}
-    protected virtual EndPoint GetLocalEndPointToBind() {}
+  }
+
+  public sealed class MuninNodeOptions {
+    public const string DefaultHostName = "munin-node.localhost";
+    public const int DefaultPort = 4949;
+
+    public static IPAddress DefaultAddress { get; }
+
+    public MuninNodeOptions() {}
+
+    public IAccessRule? AccessRule { get; set; }
+    public IPAddress Address { get; set; }
+    public string HostName { get; set; }
+    public int Port { get; set; }
+
+    public MuninNodeOptions AllowFrom(IReadOnlyList<IPAddress> addresses, bool shouldConsiderIPv4MappedIPv6Address = true) {}
+    public MuninNodeOptions AllowFromLoopbackOnly() {}
+    public MuninNodeOptions UseAnyAddress() {}
+    public MuninNodeOptions UseAnyAddress(int port) {}
+    public MuninNodeOptions UseLoopbackAddress() {}
+    public MuninNodeOptions UseLoopbackAddress(int port) {}
   }
 
   public abstract class NodeBase :
     IAsyncDisposable,
-    IDisposable
+    IDisposable,
+    IMuninNode
   {
+    [Obsolete("Use a constructor overload that takes IMuninNodeListenerFactory as an argument.")]
     protected NodeBase(IAccessRule? accessRule, ILogger? logger) {}
+    protected NodeBase(IMuninNodeListenerFactory listenerFactory, IAccessRule? accessRule, ILogger? logger) {}
 
     public virtual Encoding Encoding { get; }
+    public EndPoint EndPoint { get; }
     public abstract string HostName { get; }
+    protected IMuninNodeListener? Listener { get; }
+    [Obsolete("Use EndPoint instead.")]
     public EndPoint LocalEndPoint { get; }
     protected ILogger? Logger { get; }
     public virtual Version NodeVersion { get; }
@@ -60,13 +103,87 @@ namespace Smdn.Net.MuninNode {
 
     public async ValueTask AcceptAsync(bool throwIfCancellationRequested, CancellationToken cancellationToken) {}
     public async ValueTask AcceptSingleSessionAsync(CancellationToken cancellationToken = default) {}
-    protected abstract Socket CreateServerSocket();
+    [Obsolete("Use IMuninNodeListenerFactory and StartAsync instead.")]
+    protected virtual Socket CreateServerSocket() {}
     protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
-    protected virtual ValueTask DisposeAsyncCore() {}
+    protected virtual async ValueTask DisposeAsyncCore() {}
+    protected virtual EndPoint GetLocalEndPointToBind() {}
+    public Task RunAsync(CancellationToken cancellationToken) {}
+    [Obsolete("This method will be deprecated in the future.Use IMuninNodeListenerFactory and StartAsync instead.Make sure to override CreateServerSocket if you need to use this method.")]
     public void Start() {}
+    public ValueTask StartAsync(CancellationToken cancellationToken = default) {}
+    protected void ThrowIfDisposed() {}
     protected void ThrowIfPluginProviderIsNull() {}
+  }
+}
+
+namespace Smdn.Net.MuninNode.DependencyInjection {
+  public interface IMuninNodeBuilder {
+    string ServiceKey { get; }
+    IServiceCollection Services { get; }
+
+    IMuninNode Build(IServiceProvider serviceProvider);
+  }
+
+  public interface IMuninServiceBuilder {
+    IServiceCollection Services { get; }
+  }
+
+  public static class IMuninNodeBuilderExtensions {
+    public static IMuninNodeBuilder AddPlugin(this IMuninNodeBuilder builder, Func<IServiceProvider, IPlugin> buildPlugin) {}
+    public static IMuninNodeBuilder AddPlugin(this IMuninNodeBuilder builder, IPlugin plugin) {}
+    public static IMuninNodeBuilder UseListenerFactory(this IMuninNodeBuilder builder, Func<IServiceProvider, EndPoint, IMuninNode, CancellationToken, ValueTask<IMuninNodeListener>> createListenerAsyncFunc) {}
+    public static IMuninNodeBuilder UseListenerFactory(this IMuninNodeBuilder builder, Func<IServiceProvider, IMuninNodeListenerFactory> buildListenerFactory) {}
+    public static IMuninNodeBuilder UseListenerFactory(this IMuninNodeBuilder builder, IMuninNodeListenerFactory listenerFactory) {}
+    public static IMuninNodeBuilder UsePluginProvider(this IMuninNodeBuilder builder, Func<IServiceProvider, IPluginProvider> buildPluginProvider) {}
+    public static IMuninNodeBuilder UsePluginProvider(this IMuninNodeBuilder builder, IPluginProvider pluginProvider) {}
+    public static IMuninNodeBuilder UseSessionCallback(this IMuninNodeBuilder builder, Func<IServiceProvider, INodeSessionCallback> buildSessionCallback) {}
+    public static IMuninNodeBuilder UseSessionCallback(this IMuninNodeBuilder builder, Func<string, CancellationToken, ValueTask>? reportSessionStartedAsyncFunc, Func<string, CancellationToken, ValueTask>? reportSessionClosedAsyncFunc) {}
+    public static IMuninNodeBuilder UseSessionCallback(this IMuninNodeBuilder builder, INodeSessionCallback sessionCallback) {}
+  }
+
+  public static class IMuninServiceBuilderExtensions {
+    public static IMuninNodeBuilder AddNode(this IMuninServiceBuilder builder) {}
+    public static IMuninNodeBuilder AddNode(this IMuninServiceBuilder builder, Action<MuninNodeOptions> configure) {}
+  }
+
+  public static class IServiceCollectionExtensions {
+    public static IServiceCollection AddMunin(this IServiceCollection services, Action<IMuninServiceBuilder> configure) {}
+  }
+}
+
+namespace Smdn.Net.MuninNode.Transport {
+  public interface IMuninNodeClient :
+    IAsyncDisposable,
+    IDisposable
+  {
+    EndPoint? EndPoint { get; }
+
+    ValueTask DisconnectAsync(CancellationToken cancellationToken);
+    ValueTask<int> ReceiveAsync(IBufferWriter<byte> buffer, CancellationToken cancellationToken);
+    ValueTask SendAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken);
+  }
+
+  public interface IMuninNodeListener :
+    IAsyncDisposable,
+    IDisposable
+  {
+    EndPoint? EndPoint { get; }
+
+    ValueTask<IMuninNodeClient> AcceptAsync(CancellationToken cancellationToken);
+    ValueTask StartAsync(CancellationToken cancellationToken);
+  }
+
+  public interface IMuninNodeListenerFactory {
+    ValueTask<IMuninNodeListener> CreateAsync(EndPoint endPoint, IMuninNode node, CancellationToken cancellationToken);
+  }
+
+  public sealed class MuninNodeClientDisconnectedException : InvalidOperationException {
+    public MuninNodeClientDisconnectedException() {}
+    public MuninNodeClientDisconnectedException(string message) {}
+    public MuninNodeClientDisconnectedException(string message, Exception innerException) {}
   }
 }
 
@@ -116,6 +233,20 @@ namespace Smdn.Net.MuninPlugin {
     LineWidth2 = 102,
     LineWidth3 = 103,
     Stack = 2,
+  }
+
+  public sealed class AggregatePluginProvider :
+    ReadOnlyCollection<IPluginProvider>,
+    INodeSessionCallback,
+    IPluginProvider
+  {
+    public AggregatePluginProvider(IList<IPluginProvider> pluginProviders) {}
+
+    public IReadOnlyCollection<IPlugin> Plugins { get; }
+    INodeSessionCallback? IPluginProvider.SessionCallback { get; }
+
+    async ValueTask INodeSessionCallback.ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken) {}
+    async ValueTask INodeSessionCallback.ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken) {}
   }
 
   public class Plugin :


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #10](https://github.com/smdn/Smdn.Net.MuninNode/actions/runs/14776669271).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.MuninNode-2.2.0`
- package_prevver_ref: `releases/Smdn.Net.MuninNode-2.1.0`
- package_prevver_tag: `releases/Smdn.Net.MuninNode-2.1.0`
- package_id: `Smdn.Net.MuninNode`
- package_id_with_version: `Smdn.Net.MuninNode-2.2.0`
- package_version: `2.2.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.MuninNode-2.2.0-1746108196`
- release_tag: `releases/Smdn.Net.MuninNode-2.2.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/da8c97b4d6f85a7ed0b8fca2f0214355`](https://gist.github.com/smdn/da8c97b4d6f85a7ed0b8fca2f0214355)
- artifact_name_nupkg: `Smdn.Net.MuninNode.2.2.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.MuninNode.latest.nuspec
+++ Smdn.Net.MuninNode.2.2.0.nuspec
@@ -1,34 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.MuninNode</id>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <title>Smdn.Net.MuninNode</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.MuninNode.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.MuninNode</projectUrl>
     <description>A .NET implementation of [Munin-Node](https://guide.munin-monitoring.org/en/latest/node/index.html) and [Munin-Plugin](https://guide.munin-monitoring.org/en/latest/plugin/index.html).  This library provides Munin-Node implementation for .NET, which enables to you to create custom Munin-Node using the .NET languages and libraries.  This library also provides abstraction APIs for implementing Munin-Plugin. By using Munin-Plugin APIs in combination with the Munin-Node implementation, you can implement the function of collecting various kind of telemetry data using Munin, with .NET.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.MuninNode/releases/tag/releases%2FSmdn.Net.MuninNode-2.1.0</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.MuninNode/releases/tag/releases%2FSmdn.Net.MuninNode-2.2.0</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp Munin,Munin-Node,Munin-Plugin</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.MuninNode" branch="main" commit="16b4425cbed9d9331220cdef22e4c3e669122124" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.MuninNode" commit="04e5ff38096e4d62b2c9bc5a716d8b2c5a6ad72d" />
     <dependencies>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Options" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
-        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Options" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Encoding.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net8.0/Smdn.Net.MuninNode.dll" target="lib/net8.0/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net8.0/Smdn.Net.MuninNode.xml" target="lib/net8.0/Smdn.Net.MuninNode.xml" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/netstandard2.1/Smdn.Net.MuninNode.dll" target="lib/netstandard2.1/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/netstandard2.1/Smdn.Net.MuninNode.xml" target="lib/netstandard2.1/Smdn.Net.MuninNode.xml" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/.nuget/packages/smdn.msbuild.projectassets.common/1.4.1/project/images/package-icon.png" target="Smdn.Net.MuninNode.png" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

