### PR TITLE
Implement 'dirtyconfig' protocol extension

### DIFF
--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.Protocol/MuninProtocolHandler.Command.Cap.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.Protocol/MuninProtocolHandler.Command.Cap.cs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+using NUnit.Framework;
+
+namespace Smdn.Net.MuninNode.Protocol;
+
+#pragma warning disable IDE0040
+partial class MuninProtocolHandlerTests {
+#pragma warning restore IDE0040
+  [Test]
+  public void HandleCommandAsync_CapCommand()
+  {
+    var handler = new MuninProtocolHandler(
+      profile: new MuninNodeProfile()
+    );
+    var client = new PseudoMuninNodeClient();
+
+    Assert.That(
+      async () => await handler.HandleCommandAsync(
+        client,
+        commandLine: CreateCommandLineSequence("cap")
+      ),
+      Throws.Nothing
+    );
+
+    Assert.That(client.Responses.Count, Is.EqualTo(1));
+    Assert.That(
+      client.Responses[0],
+      Is.EqualTo("cap\n")
+    );
+  }
+
+  [TestCase("cap x-cap1")]
+  [TestCase("cap x-cap1 x-cap2")]
+  [TestCase("cap x-cap1 x-cap2 x-cap3")]
+  public void HandleCommandAsync_CapCommand_UnsupportedCapabilities(string capCommandLine)
+  {
+    var handler = new MuninProtocolHandler(
+      profile: new MuninNodeProfile()
+    );
+    var client = new PseudoMuninNodeClient();
+
+    Assert.That(
+      async () => await handler.HandleCommandAsync(
+        client,
+        commandLine: CreateCommandLineSequence(capCommandLine)
+      ),
+      Throws.Nothing
+    );
+
+    Assert.That(client.Responses.Count, Is.EqualTo(1));
+    Assert.That(
+      client.Responses[0],
+      Is.EqualTo("cap\n")
+    );
+  }
+
+  private class DirtyConfigMuninProtocolHandler(IMuninNodeProfile profile) : MuninProtocolHandler(profile) {
+    public new bool IsDirtyConfigEnabled => base.IsDirtyConfigEnabled;
+  }
+
+  [TestCase("cap dirtyconfig")]
+  [TestCase("cap  dirtyconfig")]
+  [TestCase("cap dirtyconfig ")]
+  [TestCase("cap dirtyconfig x-cap")]
+  [TestCase("cap dirtyconfig  x-cap")]
+  [TestCase("cap x-cap dirtyconfig")]
+  [TestCase("cap x-cap  dirtyconfig")]
+  public void HandleCommandAsync_CapCommand_DirtyConfig(string capCommandLine)
+  {
+    var handler = new DirtyConfigMuninProtocolHandler(
+      profile: new MuninNodeProfile()
+    );
+    var client = new PseudoMuninNodeClient();
+
+    Assert.That(handler.IsDirtyConfigEnabled, Is.False);
+
+    Assert.That(
+      async () => await handler.HandleCommandAsync(
+        client,
+        commandLine: CreateCommandLineSequence(capCommandLine)
+      ),
+      Throws.Nothing
+    );
+
+    Assert.That(client.Responses.Count, Is.EqualTo(1));
+    Assert.That(
+      client.Responses[0],
+      Is.EqualTo("cap dirtyconfig\n")
+    );
+
+    Assert.That(handler.IsDirtyConfigEnabled, Is.True);
+  }
+}

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.Protocol/MuninProtocolHandler.Commands.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.Protocol/MuninProtocolHandler.Commands.cs
@@ -116,29 +116,6 @@ partial class MuninProtocolHandlerTests {
     Assert.That(client.Connected, Is.False);
   }
 
-  [Test]
-  public void HandleCommandAsync_CapCommand()
-  {
-    var handler = new MuninProtocolHandler(
-      profile: new MuninNodeProfile()
-    );
-    var client = new PseudoMuninNodeClient();
-
-    Assert.That(
-      async () => await handler.HandleCommandAsync(
-        client,
-        commandLine: CreateCommandLineSequence("cap")
-      ),
-      Throws.Nothing
-    );
-
-    Assert.That(client.Responses.Count, Is.EqualTo(1));
-    Assert.That(
-      client.Responses[0],
-      Is.EqualTo("cap\n")
-    );
-  }
-
   private static System.Collections.IEnumerable YieldTestCases_HandleCommandAsync_VersionCommand()
   {
     foreach (var hostName in new[] { "munin-node.localhost", "_" }) {


### PR DESCRIPTION
### Description
Add support for the `dirtyconfig` protocol extension.

This PR implements processing when the `dirtyconfig` parameter is given in the `cap` command.
Also modifies the `config` response to return `field.value <value>`s when the `dirtyconfig` is enabled.

### Considerations
The default implementation of this PR will not change the environment variable `MUNIN_CAP_DIRTYCONFIG`.