### PR TITLE
Release main/Smdn.Net.MuninNode-2.4.0

### DIFF
--- a/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-2.3.0)
+// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-2.4.0)
 //   Name: Smdn.Net.MuninNode
-//   AssemblyVersion: 2.3.0.0
-//   InformationalVersion: 2.3.0+805f911ac4e163898a8e18be3121fd9baf3a44f5
+//   AssemblyVersion: 2.4.0.0
+//   InformationalVersion: 2.4.0+6578cec572157dafbc9518cc746aae28f7f1ce6d
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -120,6 +120,7 @@ namespace Smdn.Net.MuninNode {
     [Obsolete("This method will be deprecated in the future.Use IMuninNodeListenerFactory and StartAsync instead.Make sure to override CreateServerSocket if you need to use this method.")]
     public void Start() {}
     public ValueTask StartAsync(CancellationToken cancellationToken = default) {}
+    public ValueTask StopAsync(CancellationToken cancellationToken = default) {}
     protected void ThrowIfDisposed() {}
     protected void ThrowIfPluginProviderIsNull() {}
   }
@@ -182,6 +183,7 @@ namespace Smdn.Net.MuninNode.Protocol {
     public MuninProtocolHandler(IMuninNodeProfile profile) {}
 
     protected bool IsDirtyConfigEnabled { get; }
+    protected bool IsMultigraphEnabled { get; }
 
     protected virtual ValueTask HandleCapCommandAsync(IMuninNodeClient client, ReadOnlySequence<byte> arguments, CancellationToken cancellationToken) {}
     public ValueTask HandleCommandAsync(IMuninNodeClient client, ReadOnlySequence<byte> commandLine, CancellationToken cancellationToken = default) {}
@@ -196,7 +198,7 @@ namespace Smdn.Net.MuninNode.Protocol {
     public ValueTask HandleTransactionStartAsync(IMuninNodeClient client, CancellationToken cancellationToken = default) {}
     protected virtual ValueTask HandleTransactionStartAsyncCore(IMuninNodeClient client, CancellationToken cancellationToken) {}
     protected virtual ValueTask HandleVersionCommandAsync(IMuninNodeClient client, CancellationToken cancellationToken) {}
-    protected async ValueTask SendResponseAsync(IMuninNodeClient client, IEnumerable<string> responseLines, CancellationToken cancellationToken) {}
+    protected ValueTask SendResponseAsync(IMuninNodeClient client, IEnumerable<string> responseLines, CancellationToken cancellationToken) {}
   }
 
   public static class MuninProtocolHandlerFactory {
@@ -238,6 +240,10 @@ namespace Smdn.Net.MuninNode.Transport {
 }
 
 namespace Smdn.Net.MuninPlugin {
+  public interface IMultigraphPlugin : IPlugin {
+    IReadOnlyCollection<IPlugin> Plugins { get; }
+  }
+
   public interface INodeSessionCallback {
     ValueTask ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken);
     ValueTask ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken);
@@ -343,6 +349,16 @@ namespace Smdn.Net.MuninPlugin {
 
     async ValueTask INodeSessionCallback.ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken) {}
     async ValueTask INodeSessionCallback.ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken) {}
+  }
+
+  public class MultigraphPlugin : IMultigraphPlugin {
+    public MultigraphPlugin(string name, IReadOnlyCollection<IPlugin> plugins) {}
+
+    public IPluginDataSource DataSource { get; }
+    public IPluginGraphAttributes GraphAttributes { get; }
+    public string Name { get; }
+    public IReadOnlyCollection<IPlugin> Plugins { get; }
+    public INodeSessionCallback? SessionCallback { get; }
   }
 
   public class Plugin :


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #14](https://github.com/smdn/Smdn.Net.MuninNode/actions/runs/15225909898).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.MuninNode-2.4.0`
- package_prevver_ref: `releases/Smdn.Net.MuninNode-2.3.0`
- package_prevver_tag: `releases/Smdn.Net.MuninNode-2.3.0`
- package_id: `Smdn.Net.MuninNode`
- package_id_with_version: `Smdn.Net.MuninNode-2.4.0`
- package_version: `2.4.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.MuninNode-2.4.0-1748080614`
- release_tag: `releases/Smdn.Net.MuninNode-2.4.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/c6e5388d741ccae62bafffed7ce6521e`](https://gist.github.com/smdn/c6e5388d741ccae62bafffed7ce6521e)
- artifact_name_nupkg: `Smdn.Net.MuninNode.2.4.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.MuninNode.latest.nuspec
+++ Smdn.Net.MuninNode.2.4.0.nuspec
@@ -1,35 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.MuninNode</id>
-    <version>2.3.0</version>
+    <version>2.4.0</version>
     <title>Smdn.Net.MuninNode</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.MuninNode.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.MuninNode</projectUrl>
     <description>A .NET implementation of [Munin-Node](https://guide.munin-monitoring.org/en/latest/node/index.html) and [Munin-Plugin](https://guide.munin-monitoring.org/en/latest/plugin/index.html).  This library provides Munin-Node implementation for .NET, which enables to you to create custom Munin-Node using the .NET languages and libraries.  This library also provides abstraction APIs for implementing Munin-Plugin. By using Munin-Plugin APIs in combination with the Munin-Node implementation, you can implement the function of collecting various kind of telemetry data using Munin, with .NET.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.MuninNode/releases/tag/releases%2FSmdn.Net.MuninNode-2.3.0</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.MuninNode/releases/tag/releases%2FSmdn.Net.MuninNode-2.4.0</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp Munin,Munin-Node,Munin-Plugin</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.MuninNode" branch="main" commit="805f911ac4e163898a8e18be3121fd9baf3a44f5" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.MuninNode" commit="6578cec572157dafbc9518cc746aae28f7f1ce6d" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Encoding.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net8.0/Smdn.Net.MuninNode.dll" target="lib/net8.0/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net8.0/Smdn.Net.MuninNode.xml" target="lib/net8.0/Smdn.Net.MuninNode.xml" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/netstandard2.1/Smdn.Net.MuninNode.dll" target="lib/netstandard2.1/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/netstandard2.1/Smdn.Net.MuninNode.xml" target="lib/netstandard2.1/Smdn.Net.MuninNode.xml" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/.nuget/packages/smdn.msbuild.projectassets.common/1.4.1/project/images/package-icon.png" target="Smdn.Net.MuninNode.png" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

