### PR TITLE
Improve DI-related APIs to support custom types

### DIFF
--- a/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting.csproj
+++ b/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting.csproj
@@ -34,7 +34,7 @@ This library uses [Smdn.Net.MuninNode](https://www.nuget.org/packages/Smdn.Net.M
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <ProjectOrPackageReference ReferencePackageVersion="[2.2.0,4.0.0)" Include="..\Smdn.Net.MuninNode\Smdn.Net.MuninNode.csproj" />
+    <ProjectOrPackageReference ReferencePackageVersion="[2.5.0,4.0.0)" Include="..\Smdn.Net.MuninNode\Smdn.Net.MuninNode.csproj" />
   </ItemGroup>
 
   <Target Name="GenerateReadmeFileContent">

--- a/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/IServiceCollectionExtensions.cs
+++ b/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/IServiceCollectionExtensions.cs
@@ -29,11 +29,13 @@ public static class IServiceCollectionExtensions {
   /// <paramref name="configureNode"/> is <see langword="null"/>, or
   /// <paramref name="buildNode"/> is <see langword="null"/>.
   /// </exception>
+#pragma warning disable CS0618 // accept MuninNodeBuilder instead of IMuninNodeBuilder
   public static IServiceCollection AddHostedMuninNodeService(
     this IServiceCollection services,
     Action<MuninNodeOptions> configureNode,
     Action<IMuninNodeBuilder> buildNode
   )
+#pragma warning restore CS0618
   {
     if (services is null)
       throw new ArgumentNullException(nameof(services));

--- a/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/IServiceCollectionExtensions.cs
+++ b/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/IServiceCollectionExtensions.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 using System;
+#if SYSTEM_DIAGNOSTICS_CODEANALYSIS_DYNAMICALLYACCESSEDMEMBERSATTRIBUTE
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,8 +23,8 @@ public static class IServiceCollectionExtensions {
   /// configure the <c>Munin-Node</c> to be built.
   /// </param>
   /// <param name="buildNode">
-  /// An <see cref="Action{IMuninServiceBuilder}"/> to build <c>Munin-Node</c> using with
-  /// the <see cref="IMuninServiceBuilder"/>.
+  /// An <see cref="Action{IMuninNodeBuilder}"/> to build <c>Munin-Node</c> using with
+  /// the <see cref="IMuninNodeBuilder"/>.
   /// </param>
   /// <returns>The current <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
   /// <exception cref="ArgumentNullException">
@@ -36,36 +39,257 @@ public static class IServiceCollectionExtensions {
     Action<IMuninNodeBuilder> buildNode
   )
 #pragma warning restore CS0618
+    => AddHostedMuninNodeService<
+      MuninNodeBackgroundService,
+      IMuninNode,
+      IMuninNode,
+      MuninNodeOptions,
+      DefaultMuninNodeBuilder
+    >(
+      services: services ?? throw new ArgumentNullException(nameof(services)),
+      configureNode: configureNode ?? throw new ArgumentNullException(nameof(configureNode)),
+      createNodeBuilder: static (serviceBuilder, serviceKey) => new(serviceBuilder, serviceKey),
+      buildNode: builder => (buildNode ?? throw new ArgumentNullException(nameof(buildNode)))(builder)
+    );
+
+  private class DefaultMuninNodeBuilder(IMuninServiceBuilder serviceBuilder, string serviceKey)
+    : MuninNodeBuilder(serviceBuilder, serviceKey) {
+  }
+
+  /// <summary>
+  /// Add <typeparamref name="TMuninNodeBackgroundService"/>, which runs <typeparamref name="TMuninNode"/> as an
+  /// <see cref="Microsoft.Extensions.Hosting.IHostedService"/>, to <see cref="IServiceCollection"/>.
+  /// </summary>
+  /// <typeparam name="TMuninNodeBackgroundService">
+  /// The type of <see cref="Microsoft.Extensions.Hosting.IHostedService"/> service to add to the <seealso cref="IServiceCollection"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNode">
+  /// The type of <see cref="IMuninNode"/> service to add to the <seealso cref="IServiceCollection"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeOptions">
+  /// The extended type of <see cref="MuninNodeOptions"/> to configure the <typeparamref name="TMuninNode"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeBuilder">
+  /// The extended type of <see cref="MuninNodeBuilder"/> to build the <typeparamref name="TMuninNode"/>.
+  /// </typeparam>
+  /// <param name="services">
+  /// An <see cref="IServiceCollection"/> that the built <typeparamref name="TMuninNodeBackgroundService"/> and
+  /// <typeparamref name="TMuninNode"/> will be added to.
+  /// </param>
+  /// <param name="configureNode">
+  /// An <see cref="Action{TMuninNodeOptions}"/> to setup <typeparamref name="TMuninNodeOptions"/> to
+  /// configure the <typeparamref name="TMuninNode"/> to be built.
+  /// </param>
+  /// <param name="createNodeBuilder">
+  /// An <see cref="Func{TMuninNodeBuilder}"/> to create <typeparamref name="TMuninNodeBuilder"/> to build
+  /// the <typeparamref name="TMuninNode"/>.
+  /// </param>
+  /// <param name="buildNode">
+  /// An <see cref="Action{TMuninNodeBuilder}"/> to build <typeparamref name="TMuninNode"/> using with
+  /// the <typeparamref name="TMuninNodeBuilder"/>.
+  /// </param>
+  /// <returns>The current <see cref="IMuninNodeBuilder"/> so that additional calls can be chained.</returns>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="services"/> is <see langword="null"/>, or
+  /// <paramref name="configureNode"/> is <see langword="null"/>, or
+  /// <paramref name="createNodeBuilder"/> is <see langword="null"/>, or
+  /// <paramref name="buildNode"/> is <see langword="null"/>.
+  /// </exception>
+#pragma warning disable IDE0055
+  public static
+  IServiceCollection AddHostedMuninNodeService<
+#if SYSTEM_DIAGNOSTICS_CODEANALYSIS_DYNAMICALLYACCESSEDMEMBERSATTRIBUTE
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    TMuninNodeBackgroundService,
+    TMuninNode,
+    TMuninNodeOptions,
+    TMuninNodeBuilder
+  >(
+    this IServiceCollection services,
+    Action<TMuninNodeOptions> configureNode,
+    Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createNodeBuilder,
+    Action<TMuninNodeBuilder> buildNode
+  )
+    where TMuninNodeBackgroundService : MuninNodeBackgroundService
+    where TMuninNode : class, IMuninNode
+    where TMuninNodeOptions : MuninNodeOptions, new()
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore IDE0055
+    => AddHostedMuninNodeService<
+      TMuninNodeBackgroundService,
+      TMuninNode,
+      TMuninNode,
+      TMuninNodeOptions,
+      TMuninNodeBuilder
+    >(
+      services: services ?? throw new ArgumentNullException(nameof(services)),
+      configureNode: configureNode ?? throw new ArgumentNullException(nameof(configureNode)),
+      createNodeBuilder: createNodeBuilder ?? throw new ArgumentNullException(nameof(configureNode)),
+      buildNode: buildNode ?? throw new ArgumentNullException(nameof(buildNode))
+    );
+
+  /// <summary>
+  /// Add <typeparamref name="TMuninNodeBackgroundService"/>, which runs <typeparamref name="TMuninNodeImplementation"/> as an
+  /// <see cref="Microsoft.Extensions.Hosting.IHostedService"/>, to <see cref="IServiceCollection"/>.
+  /// </summary>
+  /// <typeparam name="TMuninNodeBackgroundService">
+  /// The type of <see cref="Microsoft.Extensions.Hosting.IHostedService"/> service to add to the <seealso cref="IServiceCollection"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeService">
+  /// The type of <see cref="IMuninNode"/> service to add to the <seealso cref="IServiceCollection"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeImplementation">
+  /// The type of <typeparamref name="TMuninNodeService"/> implementation.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeOptions">
+  /// The extended type of <see cref="MuninNodeOptions"/> to configure the <typeparamref name="TMuninNodeImplementation"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeBuilder">
+  /// The extended type of <see cref="MuninNodeBuilder"/> to build the <typeparamref name="TMuninNodeImplementation"/>.
+  /// </typeparam>
+  /// <param name="services">
+  /// An <see cref="IServiceCollection"/> that the built <typeparamref name="TMuninNodeBackgroundService"/> and
+  /// <typeparamref name="TMuninNodeImplementation"/> will be added to.
+  /// </param>
+  /// <param name="configureNode">
+  /// An <see cref="Action{TMuninNodeOptions}"/> to setup <typeparamref name="TMuninNodeOptions"/> to
+  /// configure the <typeparamref name="TMuninNodeImplementation"/> to be built.
+  /// </param>
+  /// <param name="createNodeBuilder">
+  /// An <see cref="Func{TMuninNodeBuilder}"/> to create <typeparamref name="TMuninNodeBuilder"/> to build
+  /// the <typeparamref name="TMuninNodeImplementation"/>.
+  /// </param>
+  /// <param name="buildNode">
+  /// An <see cref="Action{TMuninNodeBuilder}"/> to build <typeparamref name="TMuninNodeImplementation"/> using with
+  /// the <typeparamref name="TMuninNodeBuilder"/>.
+  /// </param>
+  /// <returns>The current <see cref="IMuninNodeBuilder"/> so that additional calls can be chained.</returns>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="services"/> is <see langword="null"/>, or
+  /// <paramref name="configureNode"/> is <see langword="null"/>, or
+  /// <paramref name="createNodeBuilder"/> is <see langword="null"/>, or
+  /// <paramref name="buildNode"/> is <see langword="null"/>.
+  /// </exception>
+#pragma warning disable IDE0055
+  public static
+  IServiceCollection AddHostedMuninNodeService<
+#if SYSTEM_DIAGNOSTICS_CODEANALYSIS_DYNAMICALLYACCESSEDMEMBERSATTRIBUTE
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    TMuninNodeBackgroundService,
+    TMuninNodeService,
+    TMuninNodeImplementation,
+    TMuninNodeOptions,
+    TMuninNodeBuilder
+  >(
+    this IServiceCollection services,
+    Action<TMuninNodeOptions> configureNode,
+    Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createNodeBuilder,
+    Action<TMuninNodeBuilder> buildNode
+  )
+    where TMuninNodeBackgroundService : MuninNodeBackgroundService
+    where TMuninNodeService : class, IMuninNode
+    where TMuninNodeImplementation : class, TMuninNodeService
+    where TMuninNodeOptions : MuninNodeOptions, new()
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore IDE0055
   {
     if (services is null)
       throw new ArgumentNullException(nameof(services));
     if (configureNode is null)
       throw new ArgumentNullException(nameof(configureNode));
+    if (createNodeBuilder is null)
+      throw new ArgumentNullException(nameof(createNodeBuilder));
     if (buildNode is null)
       throw new ArgumentNullException(nameof(buildNode));
 
-    return services.AddMunin(
-      muninBuilder => {
-        var muninNodeBuilder = muninBuilder.AddNode(configureNode);
+    return AddHostedMuninNodeService<TMuninNodeBackgroundService, TMuninNodeBuilder>(
+      services: services,
+      buildMunin: muninBuilder => {
+        var muninNodeBuilder = muninBuilder.AddNode<
+          TMuninNodeService,
+          TMuninNodeImplementation,
+          TMuninNodeOptions,
+          TMuninNodeBuilder
+        >(
+          configureNode,
+          createNodeBuilder
+        );
 
         buildNode(muninNodeBuilder);
 
-        muninNodeBuilder.Services.AddHostedService<MuninNodeBackgroundService>();
+        return muninNodeBuilder;
+      }
+    );
+  }
+
+  /// <summary>
+  /// Add <typeparamref name="TMuninNodeBackgroundService"/>, which runs <c>Munin-Node</c> as an
+  /// <see cref="Microsoft.Extensions.Hosting.IHostedService"/>, to <see cref="IServiceCollection"/>.
+  /// </summary>
+  /// <typeparam name="TMuninNodeBackgroundService">
+  /// The type of <see cref="Microsoft.Extensions.Hosting.IHostedService"/> service to add to the <seealso cref="IServiceCollection"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeBuilder">
+  /// The extended type of <see cref="MuninNodeBuilder"/> to build the <c>Munin-Node</c>.
+  /// </typeparam>
+  /// <param name="services">
+  /// An <see cref="IServiceCollection"/> that the built <typeparamref name="TMuninNodeBackgroundService"/> and
+  /// <c>Munin-Node</c> will be added to.
+  /// </param>
+  /// <param name="buildMunin">
+  /// A <see cref="Func{IMuninServiceBuilder, TMuninNodeBuilder}"/> that registers at least one <see cref="IMuninNode"/> to
+  /// <paramref name="services"/> and returns <typeparamref name="TMuninNodeBuilder"/>, which builds the <see cref="IMuninNode"/>
+  /// to be registered.
+  /// </param>
+  /// <returns>The current <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="services"/> is <see langword="null"/>, or
+  /// <paramref name="buildMunin"/> is <see langword="null"/>.
+  /// </exception>
+  /// <remarks>
+  /// In future implementations, <typeparamref name="TMuninNodeBackgroundService"/> to be registered by
+  /// this method will use the same key as the <see cref="MuninNodeBuilder.ServiceKey"/> of the
+  /// <typeparamref name="TMuninNodeBuilder"/> returned by the <paramref name="buildMunin"/>.
+  /// </remarks>
+#pragma warning disable IDE0055
+  public static
+  IServiceCollection AddHostedMuninNodeService<
+#if SYSTEM_DIAGNOSTICS_CODEANALYSIS_DYNAMICALLYACCESSEDMEMBERSATTRIBUTE
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    TMuninNodeBackgroundService,
+    TMuninNodeBuilder
+  >(
+    this IServiceCollection services,
+    Func<IMuninServiceBuilder, TMuninNodeBuilder> buildMunin
+  )
+    where TMuninNodeBackgroundService : MuninNodeBackgroundService
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore IDE0055
+  {
+    if (services is null)
+      throw new ArgumentNullException(nameof(services));
+    if (buildMunin is null)
+      throw new ArgumentNullException(nameof(buildMunin));
+
+    return services.AddMunin(
+      muninBuilder => {
+        var muninNodeBuilder = buildMunin(muninBuilder);
+
+        muninNodeBuilder.Services.AddHostedService<TMuninNodeBackgroundService>();
 
         // TODO: support keyed service
 #if false
-        var muninNodeBuilder = muninBuilder.AddKeyedNode(configureNode);
-
-        buildNode(muninNodeBuilder);
-
         // these code does not work currently
         // https://github.com/dotnet/runtime/issues/99085
-        muninNodeBuilder.Services.AddHostedService<MuninNodeBackgroundService>(
+        muninNodeBuilder.Services.AddHostedService<TMuninNodeBackgroundService>(
           serviceKey: muninNodeBuilder.ServiceKey
         );
 
         muninNodeBuilder.Services.TryAddEnumerable(
-          ServiceDescriptor.KeyedSingleton<IHostedService, MuninNodeBackgroundService>(
+          ServiceDescriptor.KeyedSingleton<IHostedService, TMuninNodeBackgroundService>(
             serviceKey: muninNodeBuilder.ServiceKey
           )
         );

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilder.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilder.cs
@@ -14,6 +14,7 @@ namespace Smdn.Net.MuninNode.DependencyInjection;
 /// <see cref="IMuninNodeBuilderExtensions.AddPlugin"/>
 /// <see cref="IMuninNodeBuilderExtensions.UseListenerFactory"/>
 /// <see cref="IMuninNodeBuilderExtensions.UseSessionCallback"/>
+[Obsolete($"Use or inherit {nameof(MuninNodeBuilder)} instead.")]
 public interface IMuninNodeBuilder {
   /// <summary>
   /// Gets the <see cref="IServiceCollection"/> where the <c>Munin-Node</c> services are configured.

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
@@ -48,10 +48,10 @@ public static class IMuninNodeBuilderExtensions {
     if (buildPlugin is null)
       throw new ArgumentNullException(nameof(buildPlugin));
 
-    if (builder is not DefaultMuninNodeBuilder defaultMuninNodeBuilder)
+    if (builder is not MuninNodeBuilder muninNodeBuilder)
       throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
 
-    defaultMuninNodeBuilder.AddPluginFactory(buildPlugin);
+    muninNodeBuilder.AddPluginFactory(buildPlugin);
 
     return builder;
   }
@@ -94,10 +94,10 @@ public static class IMuninNodeBuilderExtensions {
     if (buildPluginProvider is null)
       throw new ArgumentNullException(nameof(buildPluginProvider));
 
-    if (builder is not DefaultMuninNodeBuilder defaultMuninNodeBuilder)
+    if (builder is not MuninNodeBuilder muninNodeBuilder)
       throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
 
-    defaultMuninNodeBuilder.SetPluginProviderFactory(buildPluginProvider);
+    muninNodeBuilder.SetPluginProviderFactory(buildPluginProvider);
 
     return builder;
   }
@@ -171,10 +171,10 @@ public static class IMuninNodeBuilderExtensions {
     if (buildSessionCallback is null)
       throw new ArgumentNullException(nameof(buildSessionCallback));
 
-    if (builder is not DefaultMuninNodeBuilder defaultMuninNodeBuilder)
+    if (builder is not MuninNodeBuilder muninNodeBuilder)
       throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
 
-    defaultMuninNodeBuilder.SetSessionCallbackFactory(buildSessionCallback);
+    muninNodeBuilder.SetSessionCallbackFactory(buildSessionCallback);
 
     return builder;
   }
@@ -232,10 +232,10 @@ public static class IMuninNodeBuilderExtensions {
     if (buildListenerFactory is null)
       throw new ArgumentNullException(nameof(buildListenerFactory));
 
-    if (builder is not DefaultMuninNodeBuilder defaultMuninNodeBuilder)
+    if (builder is not MuninNodeBuilder muninNodeBuilder)
       throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
 
-    defaultMuninNodeBuilder.SetListenerFactory(buildListenerFactory);
+    muninNodeBuilder.SetListenerFactory(buildListenerFactory);
 
     return builder;
   }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
@@ -11,7 +11,16 @@ using Smdn.Net.MuninPlugin;
 
 namespace Smdn.Net.MuninNode.DependencyInjection;
 
+[Obsolete($"Use {nameof(MuninNodeBuilderExtensions)} instead.")]
 public static class IMuninNodeBuilderExtensions {
+  private static MuninNodeBuilder ThrowIfBuilderTypeIsNotSupported(IMuninNodeBuilder builder)
+  {
+    if (builder is not MuninNodeBuilder muninNodeBuilder)
+      throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
+
+    return muninNodeBuilder;
+  }
+
 #pragma warning disable CS0419
   /// <remarks>
   /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
@@ -21,17 +30,10 @@ public static class IMuninNodeBuilderExtensions {
     IPlugin plugin
   )
 #pragma warning restore CS0419
-  {
-    if (builder is null)
-      throw new ArgumentNullException(nameof(builder));
-    if (plugin is null)
-      throw new ArgumentNullException(nameof(plugin));
-
-    return AddPlugin(
-      builder: builder,
-      buildPlugin: _ => plugin
+    => MuninNodeBuilderExtensions.AddPlugin(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      plugin: plugin ?? throw new ArgumentNullException(nameof(plugin))
     );
-  }
 
 #pragma warning disable CS0419
   /// <remarks>
@@ -42,19 +44,10 @@ public static class IMuninNodeBuilderExtensions {
     Func<IServiceProvider, IPlugin> buildPlugin
   )
 #pragma warning restore CS0419
-  {
-    if (builder is null)
-      throw new ArgumentNullException(nameof(builder));
-    if (buildPlugin is null)
-      throw new ArgumentNullException(nameof(buildPlugin));
-
-    if (builder is not MuninNodeBuilder muninNodeBuilder)
-      throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
-
-    muninNodeBuilder.AddPluginFactory(buildPlugin);
-
-    return builder;
-  }
+    => MuninNodeBuilderExtensions.AddPlugin(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      buildPlugin: buildPlugin ?? throw new ArgumentNullException(nameof(buildPlugin))
+    );
 
 #pragma warning disable CS0419
   /// <remarks>
@@ -66,17 +59,10 @@ public static class IMuninNodeBuilderExtensions {
     IPluginProvider pluginProvider
   )
 #pragma warning restore CS0419
-  {
-    if (builder is null)
-      throw new ArgumentNullException(nameof(builder));
-    if (pluginProvider is null)
-      throw new ArgumentNullException(nameof(pluginProvider));
-
-    return UsePluginProvider(
-      builder: builder,
-      buildPluginProvider: _ => pluginProvider
+    => MuninNodeBuilderExtensions.UsePluginProvider(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      pluginProvider: pluginProvider ?? throw new ArgumentNullException(nameof(pluginProvider))
     );
-  }
 
 #pragma warning disable CS0419
   /// <remarks>
@@ -88,19 +74,10 @@ public static class IMuninNodeBuilderExtensions {
     Func<IServiceProvider, IPluginProvider> buildPluginProvider
   )
 #pragma warning restore CS0419
-  {
-    if (builder is null)
-      throw new ArgumentNullException(nameof(builder));
-    if (buildPluginProvider is null)
-      throw new ArgumentNullException(nameof(buildPluginProvider));
-
-    if (builder is not MuninNodeBuilder muninNodeBuilder)
-      throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
-
-    muninNodeBuilder.SetPluginProviderFactory(buildPluginProvider);
-
-    return builder;
-  }
+    => MuninNodeBuilderExtensions.UsePluginProvider(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      buildPluginProvider: buildPluginProvider ?? throw new ArgumentNullException(nameof(buildPluginProvider))
+    );
 
 #pragma warning disable CS0419
   /// <remarks>
@@ -111,17 +88,10 @@ public static class IMuninNodeBuilderExtensions {
     INodeSessionCallback sessionCallback
   )
 #pragma warning restore CS0419
-  {
-    if (builder is null)
-      throw new ArgumentNullException(nameof(builder));
-    if (sessionCallback is null)
-      throw new ArgumentNullException(nameof(sessionCallback));
-
-    return UseSessionCallback(
-      builder: builder,
-      buildSessionCallback: _ => sessionCallback
+    => MuninNodeBuilderExtensions.UseSessionCallback(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      sessionCallback: sessionCallback ?? throw new ArgumentNullException(nameof(sessionCallback))
     );
-  }
 
 #pragma warning disable CS0419
   /// <remarks>
@@ -133,28 +103,11 @@ public static class IMuninNodeBuilderExtensions {
     Func<string, CancellationToken, ValueTask>? reportSessionClosedAsyncFunc
   )
 #pragma warning restore CS0419
-    => UseSessionCallback(
-      builder: builder,
-      buildSessionCallback: _ => new SessionCallbackFuncWrapper(
-        reportSessionStartedAsyncFunc,
-        reportSessionClosedAsyncFunc
-      )
+    => MuninNodeBuilderExtensions.UseSessionCallback(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      reportSessionStartedAsyncFunc: reportSessionStartedAsyncFunc,
+      reportSessionClosedAsyncFunc: reportSessionClosedAsyncFunc
     );
-
-  private sealed class SessionCallbackFuncWrapper(
-    Func<string, CancellationToken, ValueTask>? reportSessionStartedAsyncFunc,
-    Func<string, CancellationToken, ValueTask>? reportSessionClosedAsyncFunc
-  ) : INodeSessionCallback {
-    public ValueTask ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken)
-      => reportSessionStartedAsyncFunc is null
-        ? default
-        : reportSessionStartedAsyncFunc(sessionId, cancellationToken);
-
-    public ValueTask ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken)
-      => reportSessionClosedAsyncFunc is null
-        ? default
-        : reportSessionClosedAsyncFunc(sessionId, cancellationToken);
-  }
 
 #pragma warning disable CS0419
   /// <remarks>
@@ -165,96 +118,35 @@ public static class IMuninNodeBuilderExtensions {
     Func<IServiceProvider, INodeSessionCallback> buildSessionCallback
   )
 #pragma warning restore CS0419
-  {
-    if (builder is null)
-      throw new ArgumentNullException(nameof(builder));
-    if (buildSessionCallback is null)
-      throw new ArgumentNullException(nameof(buildSessionCallback));
-
-    if (builder is not MuninNodeBuilder muninNodeBuilder)
-      throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
-
-    muninNodeBuilder.SetSessionCallbackFactory(buildSessionCallback);
-
-    return builder;
-  }
+    => MuninNodeBuilderExtensions.UseSessionCallback(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      buildSessionCallback: buildSessionCallback ?? throw new ArgumentNullException(nameof(buildSessionCallback))
+    );
 
   public static IMuninNodeBuilder UseListenerFactory(
     this IMuninNodeBuilder builder,
     IMuninNodeListenerFactory listenerFactory
   )
-  {
-    if (builder is null)
-      throw new ArgumentNullException(nameof(builder));
-    if (listenerFactory is null)
-      throw new ArgumentNullException(nameof(listenerFactory));
-
-    return UseListenerFactory(
-      builder: builder,
-      buildListenerFactory: _ => listenerFactory
+    => MuninNodeBuilderExtensions.UseListenerFactory(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      listenerFactory: listenerFactory ?? throw new ArgumentNullException(nameof(listenerFactory))
     );
-  }
 
   public static IMuninNodeBuilder UseListenerFactory(
     this IMuninNodeBuilder builder,
     Func<IServiceProvider, EndPoint, IMuninNode, CancellationToken, ValueTask<IMuninNodeListener>> createListenerAsyncFunc
   )
-  {
-    if (builder is null)
-      throw new ArgumentNullException(nameof(builder));
-    if (createListenerAsyncFunc is null)
-      throw new ArgumentNullException(nameof(createListenerAsyncFunc));
-
-    return UseListenerFactory(
-      builder: builder,
-      buildListenerFactory: serviceProvider => new CreateListenerAsyncFuncWrapper(
-        serviceProvider,
-        createListenerAsyncFunc
-      )
+    => MuninNodeBuilderExtensions.UseListenerFactory(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      createListenerAsyncFunc: createListenerAsyncFunc ?? throw new ArgumentNullException(nameof(createListenerAsyncFunc))
     );
-  }
-
-  private sealed class CreateListenerAsyncFuncWrapper(
-    IServiceProvider serviceProvider,
-    Func<IServiceProvider, EndPoint, IMuninNode, CancellationToken, ValueTask<IMuninNodeListener>> createListenerAsyncFunc
-  ) : IMuninNodeListenerFactory {
-    public ValueTask<IMuninNodeListener> CreateAsync(EndPoint endPoint, IMuninNode node, CancellationToken cancellationToken)
-      => createListenerAsyncFunc(serviceProvider, endPoint, node, cancellationToken);
-  }
 
   public static IMuninNodeBuilder UseListenerFactory(
     this IMuninNodeBuilder builder,
     Func<IServiceProvider, IMuninNodeListenerFactory> buildListenerFactory
   )
-  {
-    if (builder is null)
-      throw new ArgumentNullException(nameof(builder));
-    if (buildListenerFactory is null)
-      throw new ArgumentNullException(nameof(buildListenerFactory));
-
-    if (builder is not MuninNodeBuilder muninNodeBuilder)
-      throw new NotSupportedException($"The builder implementation of type `{builder.GetType().FullName}` does not support service key configuration.");
-
-    muninNodeBuilder.SetListenerFactory(buildListenerFactory);
-
-    return builder;
-  }
-
-  internal static TMuninNode Build<TMuninNode>(
-    this IMuninNodeBuilder builder,
-    IServiceProvider serviceProvider
-  ) where TMuninNode : IMuninNode
-  {
-    if (builder is null)
-      throw new ArgumentNullException(nameof(builder));
-    if (serviceProvider is null)
-      throw new ArgumentNullException(nameof(serviceProvider));
-
-    var n = builder.Build(serviceProvider);
-
-    if (n is not TMuninNode node)
-      throw new InvalidOperationException($"The type '{n.GetType()}' of the constructed instance did not match the requested type '{typeof(TMuninNode)}'.");
-
-    return node;
-  }
+    => MuninNodeBuilderExtensions.UseListenerFactory(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      buildListenerFactory: buildListenerFactory ?? throw new ArgumentNullException(nameof(buildListenerFactory))
+    );
 }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
@@ -239,4 +239,22 @@ public static class IMuninNodeBuilderExtensions {
 
     return builder;
   }
+
+  internal static TMuninNode Build<TMuninNode>(
+    this IMuninNodeBuilder builder,
+    IServiceProvider serviceProvider
+  ) where TMuninNode : IMuninNode
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (serviceProvider is null)
+      throw new ArgumentNullException(nameof(serviceProvider));
+
+    var n = builder.Build(serviceProvider);
+
+    if (n is not TMuninNode node)
+      throw new InvalidOperationException($"The type '{n.GetType()}' of the constructed instance did not match the requested type '{typeof(TMuninNode)}'.");
+
+    return node;
+  }
 }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
@@ -38,9 +38,13 @@ public static class IMuninServiceBuilderExtensions {
     this IMuninServiceBuilder builder,
     Action<MuninNodeOptions> configure
   )
-    => AddNode<MuninNodeOptions>(
+    => AddNode<
+      MuninNodeOptions,
+      MuninNodeBuilder
+    >(
       builder: builder ?? throw new ArgumentNullException(nameof(builder)),
-      configure: configure ?? throw new ArgumentNullException(nameof(configure))
+      configure: configure ?? throw new ArgumentNullException(nameof(configure)),
+      createBuilder: static (serviceBuilder, serviceKey) => new(serviceBuilder, serviceKey)
     );
 
   /// <summary>
@@ -49,6 +53,9 @@ public static class IMuninServiceBuilderExtensions {
   /// <typeparam name="TMuninNodeOptions">
   /// The extended type of <see cref="MuninNodeOptions"/> to configure the <c>Munin-Node</c>.
   /// </typeparam>
+  /// <typeparam name="TMuninNodeBuilder">
+  /// The extended type of <see cref="MuninNodeBuilder"/> to build the <c>Munin-Node</c>.
+  /// </typeparam>
   /// <param name="builder">
   /// An <see cref="IMuninServiceBuilder"/> that the built <c>Munin-Node</c> will be added to.
   /// </param>
@@ -56,25 +63,42 @@ public static class IMuninServiceBuilderExtensions {
   /// An <see cref="Action{TMuninNodeOptions}"/> to setup <typeparamref name="TMuninNodeOptions"/> to
   /// configure the <c>Munin-Node</c> to be built.
   /// </param>
+  /// <param name="createBuilder">
+  /// An <see cref="Func{TMuninNodeBuilder}"/> to create <typeparamref name="TMuninNodeBuilder"/> to build
+  /// the <c>Munin-Node</c>.
+  /// </param>
   /// <returns>The current <see cref="IMuninNodeBuilder"/> so that additional calls can be chained.</returns>
-  public static IMuninNodeBuilder AddNode<TMuninNodeOptions>(
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="builder"/> is <see langword="null"/>, or
+  /// <paramref name="configure"/> is <see langword="null"/>, or
+  /// <paramref name="createBuilder"/> is <see langword="null"/>.
+  /// </exception>
+  public static
+  IMuninNodeBuilder AddNode<
+    TMuninNodeOptions,
+    TMuninNodeBuilder
+  >(
     this IMuninServiceBuilder builder,
-    Action<TMuninNodeOptions> configure
+    Action<TMuninNodeOptions> configure,
+    Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createBuilder
   )
     where TMuninNodeOptions : MuninNodeOptions, new()
+    where TMuninNodeBuilder : MuninNodeBuilder
   {
     if (builder is null)
       throw new ArgumentNullException(nameof(builder));
     if (configure is null)
       throw new ArgumentNullException(nameof(configure));
+    if (createBuilder is null)
+      throw new ArgumentNullException(nameof(createBuilder));
 
     var configuredOptions = new TMuninNodeOptions();
 
     configure(configuredOptions);
 
-    var nodeBuilder = new MuninNodeBuilder(
-      serviceBuilder: builder,
-      serviceKey: configuredOptions.HostName // use configured hostname as a service key and option name
+    var nodeBuilder = createBuilder(
+      /* serviceBuilder: */ builder,
+      /* serviceKey: */ configuredOptions.HostName // use configured hostname as a service key and option name
     );
 
     _ = builder.Services.Configure<TMuninNodeOptions>(

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
@@ -46,7 +46,7 @@ public static class IMuninServiceBuilderExtensions {
 
     configure(options);
 
-    var nodeBuilder = new DefaultMuninNodeBuilder(
+    var nodeBuilder = new MuninNodeBuilder(
       serviceBuilder: builder,
       serviceKey: options.HostName // use configured hostname as a service key and option name
     );

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
@@ -39,6 +39,8 @@ public static class IMuninServiceBuilderExtensions {
     Action<MuninNodeOptions> configure
   )
     => AddNode<
+      IMuninNode,
+      IMuninNode,
       MuninNodeOptions,
       MuninNodeBuilder
     >(
@@ -67,14 +69,14 @@ public static class IMuninServiceBuilderExtensions {
   /// An <see cref="Func{TMuninNodeBuilder}"/> to create <typeparamref name="TMuninNodeBuilder"/> to build
   /// the <c>Munin-Node</c>.
   /// </param>
-  /// <returns>The current <see cref="IMuninNodeBuilder"/> so that additional calls can be chained.</returns>
+  /// <returns>The current <typeparamref name="TMuninNodeBuilder"/> so that additional calls can be chained.</returns>
   /// <exception cref="ArgumentNullException">
   /// <paramref name="builder"/> is <see langword="null"/>, or
   /// <paramref name="configure"/> is <see langword="null"/>, or
   /// <paramref name="createBuilder"/> is <see langword="null"/>.
   /// </exception>
   public static
-  IMuninNodeBuilder AddNode<
+  TMuninNodeBuilder AddNode<
     TMuninNodeOptions,
     TMuninNodeBuilder
   >(
@@ -82,6 +84,117 @@ public static class IMuninServiceBuilderExtensions {
     Action<TMuninNodeOptions> configure,
     Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createBuilder
   )
+    where TMuninNodeOptions : MuninNodeOptions, new()
+    where TMuninNodeBuilder : MuninNodeBuilder
+    => AddNode<
+      IMuninNode,
+      IMuninNode,
+      TMuninNodeOptions,
+      TMuninNodeBuilder
+    >(
+      builder: builder ?? throw new ArgumentNullException(nameof(builder)),
+      configure: configure ?? throw new ArgumentNullException(nameof(configure)),
+      createBuilder: createBuilder ?? throw new ArgumentNullException(nameof(createBuilder))
+    );
+
+  /// <summary>
+  /// Adds a <typeparamref name="TMuninNode"/> to the <see cref="IMuninServiceBuilder"/> with specified configurations.
+  /// </summary>
+  /// <typeparam name="TMuninNode">
+  /// The type of <see cref="IMuninNode"/> service to add to the <seealso cref="IServiceCollection"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeOptions">
+  /// The extended type of <see cref="MuninNodeOptions"/> to configure the <typeparamref name="TMuninNode"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeBuilder">
+  /// The extended type of <see cref="MuninNodeBuilder"/> to build the <typeparamref name="TMuninNode"/>.
+  /// </typeparam>
+  /// <param name="builder">
+  /// An <see cref="IMuninServiceBuilder"/> that the built <typeparamref name="TMuninNode"/> will be added to.
+  /// </param>
+  /// <param name="configure">
+  /// An <see cref="Action{TMuninNodeOptions}"/> to setup <typeparamref name="TMuninNodeOptions"/> to
+  /// configure the <typeparamref name="TMuninNode"/> to be built.
+  /// </param>
+  /// <param name="createBuilder">
+  /// An <see cref="Func{TMuninNodeBuilder}"/> to create <typeparamref name="TMuninNodeBuilder"/> to build
+  /// the <typeparamref name="TMuninNode"/>.
+  /// </param>
+  /// <returns>The current <typeparamref name="TMuninNodeBuilder"/> so that additional calls can be chained.</returns>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="builder"/> is <see langword="null"/>, or
+  /// <paramref name="configure"/> is <see langword="null"/>, or
+  /// <paramref name="createBuilder"/> is <see langword="null"/>.
+  /// </exception>
+  public static
+  TMuninNodeBuilder AddNode<
+    TMuninNode,
+    TMuninNodeOptions,
+    TMuninNodeBuilder
+  >(
+    this IMuninServiceBuilder builder,
+    Action<TMuninNodeOptions> configure,
+    Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createBuilder
+  )
+    where TMuninNode : class, IMuninNode
+    where TMuninNodeOptions : MuninNodeOptions, new()
+    where TMuninNodeBuilder : MuninNodeBuilder
+    => AddNode<
+      TMuninNode,
+      TMuninNode,
+      TMuninNodeOptions,
+      TMuninNodeBuilder
+    >(
+      builder: builder ?? throw new ArgumentNullException(nameof(builder)),
+      configure: configure ?? throw new ArgumentNullException(nameof(configure)),
+      createBuilder: createBuilder ?? throw new ArgumentNullException(nameof(createBuilder))
+    );
+
+  /// <summary>
+  /// Adds a <typeparamref name="TMuninNodeImplementation"/> to the <see cref="IMuninServiceBuilder"/> with specified configurations.
+  /// </summary>
+  /// <typeparam name="TMuninNodeService">
+  /// The type of <see cref="IMuninNode"/> service to add to the <seealso cref="IServiceCollection"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeImplementation">
+  /// The type of <typeparamref name="TMuninNodeService"/> implementation.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeOptions">
+  /// The extended type of <see cref="MuninNodeOptions"/> to configure the <typeparamref name="TMuninNodeImplementation"/>.
+  /// </typeparam>
+  /// <typeparam name="TMuninNodeBuilder">
+  /// The extended type of <see cref="MuninNodeBuilder"/> to build the <typeparamref name="TMuninNodeImplementation"/>.
+  /// </typeparam>
+  /// <param name="builder">
+  /// An <see cref="IMuninServiceBuilder"/> that the built <typeparamref name="TMuninNodeImplementation"/> will be added to.
+  /// </param>
+  /// <param name="configure">
+  /// An <see cref="Action{TMuninNodeOptions}"/> to setup <typeparamref name="TMuninNodeOptions"/> to
+  /// configure the <typeparamref name="TMuninNodeImplementation"/> to be built.
+  /// </param>
+  /// <param name="createBuilder">
+  /// An <see cref="Func{TMuninNodeBuilder}"/> to create <typeparamref name="TMuninNodeBuilder"/> to build
+  /// the <typeparamref name="TMuninNodeImplementation"/>.
+  /// </param>
+  /// <returns>The current <see cref="IMuninNodeBuilder"/> so that additional calls can be chained.</returns>
+  /// <exception cref="ArgumentNullException">
+  /// <paramref name="builder"/> is <see langword="null"/>, or
+  /// <paramref name="configure"/> is <see langword="null"/>, or
+  /// <paramref name="createBuilder"/> is <see langword="null"/>.
+  /// </exception>
+  public static
+  TMuninNodeBuilder AddNode<
+    TMuninNodeService,
+    TMuninNodeImplementation,
+    TMuninNodeOptions,
+    TMuninNodeBuilder
+  >(
+    this IMuninServiceBuilder builder,
+    Action<TMuninNodeOptions> configure,
+    Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createBuilder
+  )
+    where TMuninNodeService : class, IMuninNode
+    where TMuninNodeImplementation : class, TMuninNodeService
     where TMuninNodeOptions : MuninNodeOptions, new()
     where TMuninNodeBuilder : MuninNodeBuilder
   {
@@ -107,7 +220,7 @@ public static class IMuninServiceBuilderExtensions {
     );
 
     builder.Services.Add(
-      ServiceDescriptor.KeyedSingleton<IMuninNodeBuilder>(
+      ServiceDescriptor.KeyedSingleton<TMuninNodeBuilder>(
         serviceKey: nodeBuilder.ServiceKey,
         implementationFactory: (_, _) => nodeBuilder
       )
@@ -115,19 +228,23 @@ public static class IMuninServiceBuilderExtensions {
 
     // add keyed/singleton IMuninNode
     builder.Services.Add(
-      ServiceDescriptor.KeyedSingleton<IMuninNode>(
+      ServiceDescriptor.KeyedSingleton<TMuninNodeService, TMuninNodeImplementation>(
         serviceKey: nodeBuilder.ServiceKey,
         static (serviceProvider, serviceKey)
-            => serviceProvider.GetRequiredKeyedService<IMuninNodeBuilder>(serviceKey).Build(serviceProvider)
+          => serviceProvider
+            .GetRequiredKeyedService<TMuninNodeBuilder>(serviceKey)
+            .Build<TMuninNodeImplementation>(serviceProvider)
       )
     );
 
     // add keyless/multiple IMuninNode
+#pragma warning disable IDE0200
     builder.Services.Add(
-      ServiceDescriptor.Transient<IMuninNode>(
-        nodeBuilder.Build
+      ServiceDescriptor.Transient<TMuninNodeService, TMuninNodeImplementation>(
+        serviceProvider => nodeBuilder.Build<TMuninNodeImplementation>(serviceProvider)
       )
     );
+#pragma warning restore IDE0200
 
     return nodeBuilder;
   }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninServiceBuilderExtensions.cs
@@ -15,9 +15,11 @@ public static class IMuninServiceBuilderExtensions {
   /// An <see cref="IMuninServiceBuilder"/> that the built <c>Munin-Node</c> will be added to.
   /// </param>
   /// <returns>The current <see cref="IMuninNodeBuilder"/> so that additional calls can be chained.</returns>
+#pragma warning disable CS0618 // TODO: return IMuninNodeBuilder instead of MuninNodeBuilder
   public static IMuninNodeBuilder AddNode(
     this IMuninServiceBuilder builder
   )
+#pragma warning restore CS0618
     => AddNode(
       builder: builder,
       configure: _ => { }
@@ -34,10 +36,12 @@ public static class IMuninServiceBuilderExtensions {
   /// configure the <c>Munin-Node</c> to be built.
   /// </param>
   /// <returns>The current <see cref="IMuninNodeBuilder"/> so that additional calls can be chained.</returns>
+#pragma warning disable CS0618 // TODO: return IMuninNodeBuilder instead of MuninNodeBuilder
   public static IMuninNodeBuilder AddNode(
     this IMuninServiceBuilder builder,
     Action<MuninNodeOptions> configure
   )
+#pragma warning restore CS0618
     => AddNode<
       IMuninNode,
       IMuninNode,

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilder.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilder.cs
@@ -14,7 +14,7 @@ using Smdn.Net.MuninPlugin;
 
 namespace Smdn.Net.MuninNode.DependencyInjection;
 
-internal sealed class DefaultMuninNodeBuilder : IMuninNodeBuilder {
+public class MuninNodeBuilder : IMuninNodeBuilder {
   private readonly List<Func<IServiceProvider, IPlugin>> pluginFactories = new(capacity: 4);
   private Func<IServiceProvider, IPluginProvider>? buildPluginProvider;
   private Func<IServiceProvider, INodeSessionCallback>? buildSessionCallback;
@@ -23,13 +23,13 @@ internal sealed class DefaultMuninNodeBuilder : IMuninNodeBuilder {
   public IServiceCollection Services { get; }
   public string ServiceKey { get; }
 
-  public DefaultMuninNodeBuilder(IMuninServiceBuilder serviceBuilder, string serviceKey)
+  internal MuninNodeBuilder(IMuninServiceBuilder serviceBuilder, string serviceKey)
   {
     Services = (serviceBuilder ?? throw new ArgumentNullException(nameof(serviceBuilder))).Services;
     ServiceKey = serviceKey ?? throw new ArgumentNullException(nameof(serviceKey));
   }
 
-  public void AddPluginFactory(Func<IServiceProvider, IPlugin> buildPlugin)
+  internal void AddPluginFactory(Func<IServiceProvider, IPlugin> buildPlugin)
   {
     if (buildPlugin is null)
       throw new ArgumentNullException(nameof(buildPlugin));
@@ -37,7 +37,7 @@ internal sealed class DefaultMuninNodeBuilder : IMuninNodeBuilder {
     pluginFactories.Add(serviceProvider => buildPlugin(serviceProvider));
   }
 
-  public void SetPluginProviderFactory(
+  internal void SetPluginProviderFactory(
     Func<IServiceProvider, IPluginProvider> buildPluginProvider
   )
   {
@@ -47,7 +47,7 @@ internal sealed class DefaultMuninNodeBuilder : IMuninNodeBuilder {
     this.buildPluginProvider = buildPluginProvider;
   }
 
-  public void SetSessionCallbackFactory(
+  internal void SetSessionCallbackFactory(
     Func<IServiceProvider, INodeSessionCallback> buildSessionCallback
   )
   {
@@ -57,7 +57,7 @@ internal sealed class DefaultMuninNodeBuilder : IMuninNodeBuilder {
     this.buildSessionCallback = buildSessionCallback;
   }
 
-  public void SetListenerFactory(
+  internal void SetListenerFactory(
     Func<IServiceProvider, IMuninNodeListenerFactory> buildListenerFactory
   )
   {

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilder.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilder.cs
@@ -73,7 +73,7 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
       throw new ArgumentNullException(nameof(serviceProvider));
 
     return new DefaultMuninNode(
-      options: serviceProvider.GetRequiredService<IOptionsMonitor<MuninNodeOptions>>().Get(name: ServiceKey),
+      options: GetConfiguredOptions<MuninNodeOptions>(serviceProvider),
       pluginProvider: buildPluginProvider is null
         ? new PluginProvider(
             plugins: pluginFactories.Select(factory => factory(serviceProvider)).ToList(),
@@ -97,5 +97,16 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
       Plugins = plugins ?? throw new ArgumentNullException(nameof(plugins));
       SessionCallback = sessionCallback;
     }
+  }
+
+  protected TMuninNodeOptions GetConfiguredOptions<TMuninNodeOptions>(IServiceProvider serviceProvider)
+    where TMuninNodeOptions : MuninNodeOptions
+  {
+    if (serviceProvider is null)
+      throw new ArgumentNullException(nameof(serviceProvider));
+
+    return serviceProvider
+      .GetRequiredService<IOptionsMonitor<TMuninNodeOptions>>()
+      .Get(name: ServiceKey);
   }
 }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilder.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilder.cs
@@ -14,13 +14,30 @@ using Smdn.Net.MuninPlugin;
 
 namespace Smdn.Net.MuninNode.DependencyInjection;
 
+/// <summary>
+/// Provides builder pattern for configuring and building the <c>Munin-Node</c>.
+/// </summary>
+/// <seealso cref="MuninNodeBuilderExtensions"/>
+#pragma warning disable CS0618 // TODO: remove IMuninNodeBuilder
 public class MuninNodeBuilder : IMuninNodeBuilder {
+#pragma warning restore CS0618
   private readonly List<Func<IServiceProvider, IPlugin>> pluginFactories = new(capacity: 4);
   private Func<IServiceProvider, IPluginProvider>? buildPluginProvider;
   private Func<IServiceProvider, INodeSessionCallback>? buildSessionCallback;
   private Func<IServiceProvider, IMuninNodeListenerFactory>? buildListenerFactory;
 
+  /// <summary>
+  /// Gets the <see cref="IServiceCollection"/> where the <c>Munin-Node</c> services are configured.
+  /// </summary>
   public IServiceCollection Services { get; }
+
+  /// <summary>
+  /// Gets the <see cref="string"/> key of <c>Munin-Node</c> service.
+  /// </summary>
+  /// <remarks>
+  /// The value set as the hostname of the <c>Munin-Node</c> (see <see cref="MuninNodeOptions.HostName"/>) is used as the service key.
+  /// </remarks>
+  /// <see cref="IMuninServiceBuilderExtensions.AddNode(IMuninServiceBuilder, Action{MuninNodeOptions})"/>
   public string ServiceKey { get; }
 
   protected internal MuninNodeBuilder(IMuninServiceBuilder serviceBuilder, string serviceKey)
@@ -67,6 +84,13 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
     this.buildListenerFactory = buildListenerFactory;
   }
 
+  /// <summary>
+  /// Builds the <c>Munin-Node</c> with current configurations.
+  /// </summary>
+  /// <param name="serviceProvider">
+  /// An <see cref="IServiceProvider"/> that provides the services to be used by the <see cref="IMuninNode"/> being built.
+  /// </param>
+  /// <returns>An initialized <see cref="IMuninNode"/>.</returns>
   public IMuninNode Build(IServiceProvider serviceProvider)
   {
     if (serviceProvider is null)

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilderExtensions.cs
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Smdn.Net.MuninNode.Transport;
+using Smdn.Net.MuninPlugin;
+
+namespace Smdn.Net.MuninNode.DependencyInjection;
+
+public static class MuninNodeBuilderExtensions {
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static TMuninNodeBuilder AddPlugin<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    IPlugin plugin
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (plugin is null)
+      throw new ArgumentNullException(nameof(plugin));
+
+    return AddPlugin(
+      builder: builder,
+      buildPlugin: _ => plugin
+    );
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static TMuninNodeBuilder AddPlugin<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    Func<IServiceProvider, IPlugin> buildPlugin
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (buildPlugin is null)
+      throw new ArgumentNullException(nameof(buildPlugin));
+
+    builder.AddPluginFactory(buildPlugin);
+
+    return builder;
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// Calling this method will override the configurations made by
+  /// <see cref="AddPlugin"/> and <see cref="UseSessionCallback"/>.
+  /// </remarks>
+  public static TMuninNodeBuilder UsePluginProvider<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    IPluginProvider pluginProvider
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (pluginProvider is null)
+      throw new ArgumentNullException(nameof(pluginProvider));
+
+    return UsePluginProvider(
+      builder: builder,
+      buildPluginProvider: _ => pluginProvider
+    );
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// Calling this method will override the configurations made by
+  /// <see cref="AddPlugin"/> and <see cref="UseSessionCallback"/>.
+  /// </remarks>
+  public static TMuninNodeBuilder UsePluginProvider<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    Func<IServiceProvider, IPluginProvider> buildPluginProvider
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (buildPluginProvider is null)
+      throw new ArgumentNullException(nameof(buildPluginProvider));
+
+    builder.SetPluginProviderFactory(buildPluginProvider);
+
+    return builder;
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    INodeSessionCallback sessionCallback
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (sessionCallback is null)
+      throw new ArgumentNullException(nameof(sessionCallback));
+
+    return UseSessionCallback(
+      builder: builder,
+      buildSessionCallback: _ => sessionCallback
+    );
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    Func<string, CancellationToken, ValueTask>? reportSessionStartedAsyncFunc,
+    Func<string, CancellationToken, ValueTask>? reportSessionClosedAsyncFunc
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore CS0419
+    => UseSessionCallback(
+      builder: builder,
+      buildSessionCallback: _ => new SessionCallbackFuncWrapper(
+        reportSessionStartedAsyncFunc,
+        reportSessionClosedAsyncFunc
+      )
+    );
+
+  private sealed class SessionCallbackFuncWrapper(
+    Func<string, CancellationToken, ValueTask>? reportSessionStartedAsyncFunc,
+    Func<string, CancellationToken, ValueTask>? reportSessionClosedAsyncFunc
+  ) : INodeSessionCallback {
+    public ValueTask ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken)
+      => reportSessionStartedAsyncFunc is null
+        ? default
+        : reportSessionStartedAsyncFunc(sessionId, cancellationToken);
+
+    public ValueTask ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken)
+      => reportSessionClosedAsyncFunc is null
+        ? default
+        : reportSessionClosedAsyncFunc(sessionId, cancellationToken);
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    Func<IServiceProvider, INodeSessionCallback> buildSessionCallback
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (buildSessionCallback is null)
+      throw new ArgumentNullException(nameof(buildSessionCallback));
+
+    builder.SetSessionCallbackFactory(buildSessionCallback);
+
+    return builder;
+  }
+
+  public static TMuninNodeBuilder UseListenerFactory<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    IMuninNodeListenerFactory listenerFactory
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (listenerFactory is null)
+      throw new ArgumentNullException(nameof(listenerFactory));
+
+    return UseListenerFactory(
+      builder: builder,
+      buildListenerFactory: _ => listenerFactory
+    );
+  }
+
+  public static TMuninNodeBuilder UseListenerFactory<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    Func<IServiceProvider, EndPoint, IMuninNode, CancellationToken, ValueTask<IMuninNodeListener>> createListenerAsyncFunc
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (createListenerAsyncFunc is null)
+      throw new ArgumentNullException(nameof(createListenerAsyncFunc));
+
+    return UseListenerFactory(
+      builder: builder,
+      buildListenerFactory: serviceProvider => new CreateListenerAsyncFuncWrapper(
+        serviceProvider,
+        createListenerAsyncFunc
+      )
+    );
+  }
+
+  private sealed class CreateListenerAsyncFuncWrapper(
+    IServiceProvider serviceProvider,
+    Func<IServiceProvider, EndPoint, IMuninNode, CancellationToken, ValueTask<IMuninNodeListener>> createListenerAsyncFunc
+  ) : IMuninNodeListenerFactory {
+    public ValueTask<IMuninNodeListener> CreateAsync(EndPoint endPoint, IMuninNode node, CancellationToken cancellationToken)
+      => createListenerAsyncFunc(serviceProvider, endPoint, node, cancellationToken);
+  }
+
+  public static TMuninNodeBuilder UseListenerFactory<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    Func<IServiceProvider, IMuninNodeListenerFactory> buildListenerFactory
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (buildListenerFactory is null)
+      throw new ArgumentNullException(nameof(buildListenerFactory));
+
+    builder.SetListenerFactory(buildListenerFactory);
+
+    return builder;
+  }
+
+  public static TMuninNode Build<TMuninNode>(
+    this MuninNodeBuilder builder,
+    IServiceProvider serviceProvider
+  ) where TMuninNode : IMuninNode
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+    if (serviceProvider is null)
+      throw new ArgumentNullException(nameof(serviceProvider));
+
+    var n = builder.Build(serviceProvider);
+
+    if (n is not TMuninNode node)
+      throw new InvalidOperationException($"The type '{n.GetType()}' of the constructed instance did not match the requested type '{typeof(TMuninNode)}'.");
+
+    return node;
+  }
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/MuninNodeOptions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/MuninNodeOptions.cs
@@ -14,7 +14,7 @@ namespace Smdn.Net.MuninNode;
 /// Options to configure the <c>Munin-Node</c>.
 /// </summary>
 /// <see cref="DependencyInjection.IMuninServiceBuilderExtensions.AddNode(DependencyInjection.IMuninServiceBuilder, Action{MuninNodeOptions})"/>
-public sealed class MuninNodeOptions {
+public class MuninNodeOptions {
   private static IPAddress LoopbackAddress => Socket.OSSupportsIPv6 ? IPAddress.IPv6Loopback : IPAddress.Loopback;
   private static IPAddress AnyAddress => Socket.OSSupportsIPv6 ? IPAddress.IPv6Any : IPAddress.Any;
 
@@ -123,6 +123,17 @@ public sealed class MuninNodeOptions {
   public MuninNodeOptions Clone()
     => (MuninNodeOptions)MemberwiseClone();
 #endif
+
+  protected internal virtual void Configure(MuninNodeOptions baseOptions)
+  {
+    if (baseOptions is null)
+      throw new ArgumentNullException(nameof(baseOptions));
+
+    Address = baseOptions.Address;
+    Port = baseOptions.Port;
+    HostName = baseOptions.HostName;
+    AccessRule = baseOptions.AccessRule;
+  }
 
   /// <summary>
   /// Set the value of the <see cref="Address"/> property to use the address of

--- a/tests/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/IServiceCollectionExtensions.cs
+++ b/tests/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/IServiceCollectionExtensions.cs
@@ -4,8 +4,13 @@ using System;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 using NUnit.Framework;
+
+using Smdn.Net.MuninNode.DependencyInjection;
+using Smdn.Net.MuninNode.Transport;
+using Smdn.Net.MuninPlugin;
 
 namespace Smdn.Net.MuninNode.Hosting;
 
@@ -55,5 +60,171 @@ public class IServiceCollectionExtensionsTests {
     var muninNodeService = serviceProvider.GetRequiredService<IHostedService>();
 
     Assert.That(muninNodeService, Is.TypeOf<MuninNodeBackgroundService>());
+  }
+
+  private class CustomMuninNodeBuilder<TMuninNodeOptions> : MuninNodeBuilder
+    where TMuninNodeOptions : MuninNodeOptions {
+    private readonly Func<TMuninNodeOptions, IPluginProvider, IMuninNodeListenerFactory?, IServiceProvider, IMuninNode> nodeFactory;
+
+    public CustomMuninNodeBuilder(
+      IMuninServiceBuilder serviceBuilder,
+      string serviceKey,
+      Func<TMuninNodeOptions, IPluginProvider, IMuninNodeListenerFactory?, IServiceProvider, IMuninNode> nodeFactory
+    )
+      : base(serviceBuilder, serviceKey)
+    {
+      this.nodeFactory = nodeFactory;
+    }
+
+    protected override IMuninNode Build(
+      IPluginProvider pluginProvider,
+      IMuninNodeListenerFactory? listenerFactory,
+      IServiceProvider serviceProvider
+    )
+      => nodeFactory(
+        GetConfiguredOptions<TMuninNodeOptions>(serviceProvider),
+        pluginProvider,
+        listenerFactory,
+        serviceProvider
+      );
+  }
+
+  private class CustomMuninNode : LocalNode {
+    public CustomMuninNodeOptions Options { get; }
+    public override string HostName => Options.HostName;
+    public override IPluginProvider PluginProvider { get; }
+
+    public string? ExtraOption => Options.ExtraOption;
+
+    public CustomMuninNode(
+      CustomMuninNodeOptions options,
+      IPluginProvider pluginProvider,
+      IMuninNodeListenerFactory? listenerFactory
+    )
+      : base(
+        listenerFactory: listenerFactory,
+        accessRule: null,
+        logger: null
+      )
+    {
+      Options = options;
+      PluginProvider = pluginProvider;
+    }
+  }
+
+  private class CustomMuninNodeOptions : MuninNodeOptions {
+    public string? ExtraOption { get; set; }
+
+    protected override void Configure(MuninNodeOptions baseOptions)
+    {
+      base.Configure(baseOptions ?? throw new ArgumentNullException(nameof(baseOptions)));
+
+      if (baseOptions is CustomMuninNodeOptions options)
+        ExtraOption = options.ExtraOption;
+    }
+  }
+
+  private class CustomMuninNodeBackgroundService(CustomMuninNode node) : MuninNodeBackgroundService(node) {
+    public string? ExtraOption => node.ExtraOption;
+  }
+
+  [Test]
+  public void AddHostedMuninNodeService_CustomBackgroundServiceType()
+  {
+    const string HostName = "munin-node.localhost";
+    const string ExtraOptionValue = "foo";
+
+    var services = new ServiceCollection();
+
+    services.AddHostedMuninNodeService<
+      CustomMuninNodeBackgroundService,
+      CustomMuninNode,
+      CustomMuninNode,
+      CustomMuninNodeOptions,
+      CustomMuninNodeBuilder<CustomMuninNodeOptions>
+    >(
+      configureNode: options => {
+        options.HostName = HostName;
+        options.ExtraOption = ExtraOptionValue;
+      },
+      createNodeBuilder: static (serviceBuilder, serviceKey) => new CustomMuninNodeBuilder<CustomMuninNodeOptions>(
+        serviceBuilder: serviceBuilder,
+        serviceKey: serviceKey,
+        nodeFactory: static (options, pluginProvider, listenerFactory, serviceProvider) => new CustomMuninNode(
+          options,
+          pluginProvider,
+          listenerFactory
+        )
+      ),
+      buildNode: nodeBuilder => { }
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    var options = serviceProvider
+      .GetRequiredService<IOptionsMonitor<CustomMuninNodeOptions>>()
+      .Get(name: HostName);
+
+    Assert.That(options.HostName, Is.EqualTo(HostName));
+    Assert.That(options.ExtraOption, Is.EqualTo(ExtraOptionValue));
+
+    var muninNodeBackgroundService = serviceProvider.GetRequiredService<IHostedService>();
+
+    Assert.That(muninNodeBackgroundService, Is.TypeOf<CustomMuninNodeBackgroundService>());
+    Assert.That(
+      (muninNodeBackgroundService as CustomMuninNodeBackgroundService)!.ExtraOption,
+      Is.EqualTo(ExtraOptionValue)
+    );
+  }
+
+  [Test]
+  public void AddHostedMuninNodeService_CustomBackgroundServiceType_WithIMuninServiceBuilder()
+  {
+    const string HostName = "munin-node.localhost";
+    const string ExtraOptionValue = "foo";
+
+    var services = new ServiceCollection();
+
+    services.AddHostedMuninNodeService<
+      CustomMuninNodeBackgroundService,
+      CustomMuninNodeBuilder<CustomMuninNodeOptions>
+    >(
+      buildMunin: muninServiceBuilder => muninServiceBuilder.AddNode<
+        CustomMuninNode,
+        CustomMuninNodeOptions,
+        CustomMuninNodeBuilder<CustomMuninNodeOptions>
+      >(
+        configure: options => {
+          options.HostName = HostName;
+          options.ExtraOption = ExtraOptionValue;
+        },
+        createBuilder: static (serviceBuilder, serviceKey) => new CustomMuninNodeBuilder<CustomMuninNodeOptions>(
+          serviceBuilder: serviceBuilder,
+          serviceKey: serviceKey,
+          nodeFactory: static (options, pluginProvider, listenerFactory, serviceProvider) => new CustomMuninNode(
+            options,
+            pluginProvider,
+            listenerFactory
+          )
+        )
+      )
+    );
+
+    var serviceProvider = services.BuildServiceProvider();
+
+    var options = serviceProvider
+      .GetRequiredService<IOptionsMonitor<CustomMuninNodeOptions>>()
+      .Get(name: HostName);
+
+    Assert.That(options.HostName, Is.EqualTo(HostName));
+    Assert.That(options.ExtraOption, Is.EqualTo(ExtraOptionValue));
+
+    var muninNodeBackgroundService = serviceProvider.GetRequiredService<IHostedService>();
+
+    Assert.That(muninNodeBackgroundService, Is.TypeOf<CustomMuninNodeBackgroundService>());
+    Assert.That(
+      (muninNodeBackgroundService as CustomMuninNodeBackgroundService)!.ExtraOption,
+      Is.EqualTo(ExtraOptionValue)
+    );
   }
 }

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
@@ -306,7 +306,7 @@ public class IMuninNodeBuilderExtensionsTests {
   private static System.Collections.IEnumerable YieldTestCases_UseSessionCallback_FuncSessionCallback()
   {
     yield return new object[] {
-      (IMuninNodeBuilder builder) => {
+      (MuninNodeBuilder builder) => {
         builder.UseSessionCallback(
           reportSessionStartedAsyncFunc: null,
           reportSessionClosedAsyncFunc: null
@@ -326,7 +326,7 @@ public class IMuninNodeBuilderExtensionsTests {
     };
 
     yield return new object[] {
-      (IMuninNodeBuilder builder) => {
+      (MuninNodeBuilder builder) => {
         builder.UseSessionCallback(
           reportSessionStartedAsyncFunc: (sessionId, ct) => throw new NotImplementedException($"sessionId={sessionId}"),
           reportSessionClosedAsyncFunc: null
@@ -350,7 +350,7 @@ public class IMuninNodeBuilderExtensionsTests {
     };
 
     yield return new object[] {
-      (IMuninNodeBuilder builder) => {
+      (MuninNodeBuilder builder) => {
         builder.UseSessionCallback(
           reportSessionStartedAsyncFunc: null,
           reportSessionClosedAsyncFunc: (sessionId, ct) => throw new NotImplementedException($"sessionId={sessionId}")
@@ -376,14 +376,14 @@ public class IMuninNodeBuilderExtensionsTests {
 
   [TestCaseSource(nameof(YieldTestCases_UseSessionCallback_FuncSessionCallback))]
   public void UseSessionCallback_FuncSessionCallback(
-    Action<IMuninNodeBuilder> callUseSessionCallback,
+    Action<MuninNodeBuilder> callUseSessionCallback,
     Action<NodeBase> assertBuiltNode
   )
   {
     var services = new ServiceCollection();
 
     services.AddMunin(
-      builder => callUseSessionCallback(builder.AddNode(option => { }))
+      builder => callUseSessionCallback((MuninNodeBuilder)builder.AddNode(option => { }))
     );
 
     var serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
### Description
Extend the dependency injection-related APIs.

This PR allows users to use the types defined by them for the node type added to `IServiceCollection` and the builder type used to configure the node.

By making `MuninNodeOptions` and `MuninNodeBuilder` public and extensible, users can extend them based on these types.
In particular, in `MuninNodeBuilder`, by changing it to be able to construct and return any implementation of `IMuninNode`, it becomes possible to register user-extended Munin nodes in `IServiceCollection`.
In addition, make changes so that `TService` and `TImplementation` can be specified when registering nodes in `IServiceCollection`.

`IMuninNodeBuilder` is being deprecated because, once `MuninNodeBuilder` is made public, it will no longer be functional as an abstract interface for defining user-defined builder types.

The outline of the API changes is as follows:

```diff
-  public sealed class MuninNodeOptions { }
+  public class MuninNodeOptions { }
 
+  [Obsolete("Use or inherit MuninNodeBuilder instead.")]
   public interface IMuninNodeBuilder { }
 
+  public class MuninNodeBuilder : IMuninNodeBuilder {
+    protected virtual IMuninNode Build(IPluginProvider pluginProvider, IMuninNodeListenerFactory? listenerFactory, IServiceProvider serviceProvider)
+  }
 
+  [Obsolete("Use MuninNodeBuilderExtensions instead.")]
   public static class IMuninNodeBuilderExtensions { }
 
+  public static class MuninNodeBuilderExtensions { }
 
   public static class IMuninServiceBuilderExtensions {
+    public static TMuninNodeBuilder AddNode<TMuninNode, TMuninNodeOptions, TMuninNodeBuilder>(this IMuninServiceBuilder builder, Action<TMuninNodeOptions> configure, Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createBuilder) where TMuninNode : class, IMuninNode where TMuninNodeOptions : MuninNodeOptions, new() where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder AddNode<TMuninNodeOptions, TMuninNodeBuilder>(this IMuninServiceBuilder builder, Action<TMuninNodeOptions> configure, Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createBuilder) where TMuninNodeOptions : MuninNodeOptions, new() where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder AddNode<TMuninNodeService, TMuninNodeImplementation, TMuninNodeOptions, TMuninNodeBuilder>(this IMuninServiceBuilder builder, Action<TMuninNodeOptions> configure, Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createBuilder) where TMuninNodeService : class, IMuninNode where TMuninNodeImplementation : class, TMuninNodeService where TMuninNodeOptions : MuninNodeOptions, new() where TMuninNodeBuilder : MuninNodeBuilder {}
 }
```