### PR TITLE
Release main/Smdn.Net.MuninNode-2.5.0

### DIFF
--- a/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.MuninNode/Smdn.Net.MuninNode-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-2.4.0)
+// Smdn.Net.MuninNode.dll (Smdn.Net.MuninNode-2.5.0)
 //   Name: Smdn.Net.MuninNode
-//   AssemblyVersion: 2.4.0.0
-//   InformationalVersion: 2.4.0+6578cec572157dafbc9518cc746aae28f7f1ce6d
+//   AssemblyVersion: 2.5.0.0
+//   InformationalVersion: 2.5.0+41ff114bf69b864033a05a389896010d3eefe4d5
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -71,7 +71,7 @@ namespace Smdn.Net.MuninNode {
     protected override Socket CreateServerSocket() {}
   }
 
-  public sealed class MuninNodeOptions {
+  public class MuninNodeOptions {
     public const string DefaultHostName = "munin-node.localhost";
     public const int DefaultPort = 4949;
 
@@ -86,6 +86,7 @@ namespace Smdn.Net.MuninNode {
 
     public MuninNodeOptions AllowFrom(IReadOnlyList<IPAddress> addresses, bool shouldConsiderIPv4MappedIPv6Address = true) {}
     public MuninNodeOptions AllowFromLoopbackOnly() {}
+    internal protected virtual void Configure(MuninNodeOptions baseOptions) {}
     public MuninNodeOptions UseAnyAddress() {}
     public MuninNodeOptions UseAnyAddress(int port) {}
     public MuninNodeOptions UseLoopbackAddress() {}
@@ -128,13 +129,18 @@ namespace Smdn.Net.MuninNode {
     [Obsolete("This method will be deprecated in the future.Use IMuninNodeListenerFactory and StartAsync instead.Make sure to override CreateServerSocket if you need to use this method.")]
     public void Start() {}
     public ValueTask StartAsync(CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask StartedAsync(CancellationToken cancellationToken) {}
+    protected virtual ValueTask StartingAsync(CancellationToken cancellationToken) {}
     public ValueTask StopAsync(CancellationToken cancellationToken = default) {}
+    protected virtual ValueTask StoppedAsync(CancellationToken cancellationToken) {}
+    protected virtual ValueTask StoppingAsync(CancellationToken cancellationToken) {}
     protected void ThrowIfDisposed() {}
     protected void ThrowIfPluginProviderIsNull() {}
   }
 }
 
 namespace Smdn.Net.MuninNode.DependencyInjection {
+  [Obsolete("Use or inherit MuninNodeBuilder instead.")]
   public interface IMuninNodeBuilder {
     string ServiceKey { get; }
     IServiceCollection Services { get; }
@@ -146,6 +152,7 @@ namespace Smdn.Net.MuninNode.DependencyInjection {
     IServiceCollection Services { get; }
   }
 
+  [Obsolete("Use MuninNodeBuilderExtensions instead.")]
   public static class IMuninNodeBuilderExtensions {
     public static IMuninNodeBuilder AddPlugin(this IMuninNodeBuilder builder, Func<IServiceProvider, IPlugin> buildPlugin) {}
     public static IMuninNodeBuilder AddPlugin(this IMuninNodeBuilder builder, IPlugin plugin) {}
@@ -162,10 +169,38 @@ namespace Smdn.Net.MuninNode.DependencyInjection {
   public static class IMuninServiceBuilderExtensions {
     public static IMuninNodeBuilder AddNode(this IMuninServiceBuilder builder) {}
     public static IMuninNodeBuilder AddNode(this IMuninServiceBuilder builder, Action<MuninNodeOptions> configure) {}
+    public static TMuninNodeBuilder AddNode<TMuninNode, TMuninNodeOptions, TMuninNodeBuilder>(this IMuninServiceBuilder builder, Action<TMuninNodeOptions> configure, Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createBuilder) where TMuninNode : class, IMuninNode where TMuninNodeOptions : MuninNodeOptions, new() where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder AddNode<TMuninNodeOptions, TMuninNodeBuilder>(this IMuninServiceBuilder builder, Action<TMuninNodeOptions> configure, Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createBuilder) where TMuninNodeOptions : MuninNodeOptions, new() where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder AddNode<TMuninNodeService, TMuninNodeImplementation, TMuninNodeOptions, TMuninNodeBuilder>(this IMuninServiceBuilder builder, Action<TMuninNodeOptions> configure, Func<IMuninServiceBuilder, string, TMuninNodeBuilder> createBuilder) where TMuninNodeService : class, IMuninNode where TMuninNodeImplementation : class, TMuninNodeService where TMuninNodeOptions : MuninNodeOptions, new() where TMuninNodeBuilder : MuninNodeBuilder {}
   }
 
   public static class IServiceCollectionExtensions {
     public static IServiceCollection AddMunin(this IServiceCollection services, Action<IMuninServiceBuilder> configure) {}
+  }
+
+  public class MuninNodeBuilder : IMuninNodeBuilder {
+    internal protected MuninNodeBuilder(IMuninServiceBuilder serviceBuilder, string serviceKey) {}
+
+    public string ServiceKey { get; }
+    public IServiceCollection Services { get; }
+
+    protected virtual IMuninNode Build(IPluginProvider pluginProvider, IMuninNodeListenerFactory? listenerFactory, IServiceProvider serviceProvider) {}
+    public IMuninNode Build(IServiceProvider serviceProvider) {}
+    protected TMuninNodeOptions GetConfiguredOptions<TMuninNodeOptions>(IServiceProvider serviceProvider) where TMuninNodeOptions : MuninNodeOptions {}
+  }
+
+  public static class MuninNodeBuilderExtensions {
+    public static TMuninNodeBuilder AddPlugin<TMuninNodeBuilder>(this TMuninNodeBuilder builder, Func<IServiceProvider, IPlugin> buildPlugin) where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder AddPlugin<TMuninNodeBuilder>(this TMuninNodeBuilder builder, IPlugin plugin) where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNode Build<TMuninNode>(this MuninNodeBuilder builder, IServiceProvider serviceProvider) where TMuninNode : IMuninNode {}
+    public static TMuninNodeBuilder UseListenerFactory<TMuninNodeBuilder>(this TMuninNodeBuilder builder, Func<IServiceProvider, EndPoint, IMuninNode, CancellationToken, ValueTask<IMuninNodeListener>> createListenerAsyncFunc) where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder UseListenerFactory<TMuninNodeBuilder>(this TMuninNodeBuilder builder, Func<IServiceProvider, IMuninNodeListenerFactory> buildListenerFactory) where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder UseListenerFactory<TMuninNodeBuilder>(this TMuninNodeBuilder builder, IMuninNodeListenerFactory listenerFactory) where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder UsePluginProvider<TMuninNodeBuilder>(this TMuninNodeBuilder builder, Func<IServiceProvider, IPluginProvider> buildPluginProvider) where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder UsePluginProvider<TMuninNodeBuilder>(this TMuninNodeBuilder builder, IPluginProvider pluginProvider) where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(this TMuninNodeBuilder builder, Func<IServiceProvider, INodeSessionCallback> buildSessionCallback) where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(this TMuninNodeBuilder builder, Func<string, CancellationToken, ValueTask>? reportSessionStartedAsyncFunc, Func<string, CancellationToken, ValueTask>? reportSessionClosedAsyncFunc) where TMuninNodeBuilder : MuninNodeBuilder {}
+    public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(this TMuninNodeBuilder builder, INodeSessionCallback sessionCallback) where TMuninNodeBuilder : MuninNodeBuilder {}
   }
 }
 
@@ -475,6 +510,8 @@ namespace Smdn.Net.MuninPlugin {
     public PluginGraphAttributesBuilder WithGraphUpperLimit(double @value) {}
     public PluginGraphAttributesBuilder WithHeight(int height) {}
     public PluginGraphAttributesBuilder WithSize(int width, int height) {}
+    [MemberNotNull("title")]
+    public PluginGraphAttributesBuilder WithTitle(string title) {}
     public PluginGraphAttributesBuilder WithTotal(string labelForTotal) {}
     public PluginGraphAttributesBuilder WithUpdateRate(TimeSpan updateRate) {}
     public PluginGraphAttributesBuilder WithVerticalLabel(string verticalLabel) {}


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #15](https://github.com/smdn/Smdn.Net.MuninNode/actions/runs/15373514554).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.MuninNode-2.5.0`
- package_prevver_ref: `releases/Smdn.Net.MuninNode-2.4.0`
- package_prevver_tag: `releases/Smdn.Net.MuninNode-2.4.0`
- package_id: `Smdn.Net.MuninNode`
- package_id_with_version: `Smdn.Net.MuninNode-2.5.0`
- package_version: `2.5.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.MuninNode-2.5.0-1748770548`
- release_tag: `releases/Smdn.Net.MuninNode-2.5.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/d25893ac96c486edc2f50ae75f27bf33`](https://gist.github.com/smdn/d25893ac96c486edc2f50ae75f27bf33)
- artifact_name_nupkg: `Smdn.Net.MuninNode.2.5.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.MuninNode.latest.nuspec
+++ Smdn.Net.MuninNode.2.5.0.nuspec
@@ -1,35 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.MuninNode</id>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
     <title>Smdn.Net.MuninNode</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.MuninNode.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.MuninNode</projectUrl>
     <description>A .NET implementation of [Munin-Node](https://guide.munin-monitoring.org/en/latest/node/index.html) and [Munin-Plugin](https://guide.munin-monitoring.org/en/latest/plugin/index.html).  This library provides Munin-Node implementation for .NET, which enables to you to create custom Munin-Node using the .NET languages and libraries.  This library also provides abstraction APIs for implementing Munin-Plugin. By using Munin-Plugin APIs in combination with the Munin-Node implementation, you can implement the function of collecting various kind of telemetry data using Munin, with .NET.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.MuninNode/releases/tag/releases%2FSmdn.Net.MuninNode-2.4.0</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.MuninNode/releases/tag/releases%2FSmdn.Net.MuninNode-2.5.0</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp Munin,Munin-Node,Munin-Plugin</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.MuninNode" branch="main" commit="6578cec572157dafbc9518cc746aae28f7f1ce6d" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.MuninNode" commit="41ff114bf69b864033a05a389896010d3eefe4d5" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Encoding.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.IO.Pipelines" version="6.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net8.0/Smdn.Net.MuninNode.dll" target="lib/net8.0/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/net8.0/Smdn.Net.MuninNode.xml" target="lib/net8.0/Smdn.Net.MuninNode.xml" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/netstandard2.1/Smdn.Net.MuninNode.dll" target="lib/netstandard2.1/Smdn.Net.MuninNode.dll" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/netstandard2.1/Smdn.Net.MuninNode.xml" target="lib/netstandard2.1/Smdn.Net.MuninNode.xml" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/.nuget/packages/smdn.msbuild.projectassets.common/1.4.1/project/images/package-icon.png" target="Smdn.Net.MuninNode.png" />
+    <file src="/home/runner/work/Smdn.Net.MuninNode/Smdn.Net.MuninNode/src/Smdn.Net.MuninNode/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

