### PR TITLE
Introduce ITransactionCallback, replacement for INodeSessionCallback

### DIFF
--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
@@ -123,6 +123,22 @@ public static class IMuninNodeBuilderExtensions {
       buildSessionCallback: buildSessionCallback ?? throw new ArgumentNullException(nameof(buildSessionCallback))
     );
 
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static IMuninNodeBuilder UseTransactionCallback(
+    this IMuninNodeBuilder builder,
+    Func<CancellationToken, ValueTask>? onStartTransactionAsyncFunc,
+    Func<CancellationToken, ValueTask>? onEndTransactionAsyncFunc
+  )
+#pragma warning restore CS0419
+    => MuninNodeBuilderExtensions.UseTransactionCallback(
+      builder: ThrowIfBuilderTypeIsNotSupported(builder ?? throw new ArgumentNullException(nameof(builder))),
+      onStartTransactionAsyncFunc: onStartTransactionAsyncFunc,
+      onEndTransactionAsyncFunc: onEndTransactionAsyncFunc
+    );
+
   public static IMuninNodeBuilder UseListenerFactory(
     this IMuninNodeBuilder builder,
     IMuninNodeListenerFactory listenerFactory

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilder.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilder.cs
@@ -23,7 +23,7 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
 #pragma warning restore CS0618
   private readonly List<Func<IServiceProvider, IPlugin>> pluginFactories = new(capacity: 4);
   private Func<IServiceProvider, IPluginProvider>? buildPluginProvider;
-  private Func<IServiceProvider, INodeSessionCallback>? buildSessionCallback;
+  [Obsolete] private Func<IServiceProvider, INodeSessionCallback>? buildSessionCallback;
   private Func<IServiceProvider, IMuninNodeListenerFactory>? buildListenerFactory;
 
   /// <summary>
@@ -64,6 +64,7 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
     this.buildPluginProvider = buildPluginProvider;
   }
 
+  [Obsolete]
   internal void SetSessionCallbackFactory(
     Func<IServiceProvider, INodeSessionCallback> buildSessionCallback
   )
@@ -100,7 +101,9 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
       pluginProvider: buildPluginProvider is null
         ? new PluginProvider(
             plugins: pluginFactories.Select(factory => factory(serviceProvider)).ToList(),
+#pragma warning disable CS0612
             sessionCallback: buildSessionCallback?.Invoke(serviceProvider)
+#pragma warning restore CS0612
           )
         : buildPluginProvider.Invoke(serviceProvider),
       listenerFactory: buildListenerFactory?.Invoke(serviceProvider),
@@ -110,15 +113,22 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
 
   private sealed class PluginProvider : IPluginProvider {
     public IReadOnlyCollection<IPlugin> Plugins { get; }
+
+    [Obsolete]
     public INodeSessionCallback? SessionCallback { get; }
 
     public PluginProvider(
       IReadOnlyCollection<IPlugin> plugins,
+#pragma warning disable CS0618
       INodeSessionCallback? sessionCallback
+#pragma warning restore CS0618
     )
     {
       Plugins = plugins ?? throw new ArgumentNullException(nameof(plugins));
+
+#pragma warning disable CS0612
       SessionCallback = sessionCallback;
+#pragma warning restore CS0612
     }
   }
 

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilder.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilder.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -24,6 +26,8 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
   private readonly List<Func<IServiceProvider, IPlugin>> pluginFactories = new(capacity: 4);
   private Func<IServiceProvider, IPluginProvider>? buildPluginProvider;
   [Obsolete] private Func<IServiceProvider, INodeSessionCallback>? buildSessionCallback;
+  private Func<CancellationToken, ValueTask>? onStartTransactionAsyncFunc;
+  private Func<CancellationToken, ValueTask>? onEndTransactionAsyncFunc;
   private Func<IServiceProvider, IMuninNodeListenerFactory>? buildListenerFactory;
 
   /// <summary>
@@ -75,6 +79,15 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
     this.buildSessionCallback = buildSessionCallback;
   }
 
+  internal void SetTransactionCallback(
+    Func<CancellationToken, ValueTask>? onStartTransactionAsyncFunc,
+    Func<CancellationToken, ValueTask>? onEndTransactionAsyncFunc
+  )
+  {
+    this.onStartTransactionAsyncFunc = onStartTransactionAsyncFunc;
+    this.onEndTransactionAsyncFunc = onEndTransactionAsyncFunc;
+  }
+
   internal void SetListenerFactory(
     Func<IServiceProvider, IMuninNodeListenerFactory> buildListenerFactory
   )
@@ -102,8 +115,10 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
         ? new PluginProvider(
             plugins: pluginFactories.Select(factory => factory(serviceProvider)).ToList(),
 #pragma warning disable CS0612
-            sessionCallback: buildSessionCallback?.Invoke(serviceProvider)
+            sessionCallback: buildSessionCallback?.Invoke(serviceProvider),
 #pragma warning restore CS0612
+            onStartTransactionAsyncFunc: onStartTransactionAsyncFunc,
+            onEndTransactionAsyncFunc: onEndTransactionAsyncFunc
           )
         : buildPluginProvider.Invoke(serviceProvider),
       listenerFactory: buildListenerFactory?.Invoke(serviceProvider),
@@ -111,17 +126,22 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
     );
   }
 
-  private sealed class PluginProvider : IPluginProvider {
+  private sealed class PluginProvider : IPluginProvider, ITransactionCallback {
     public IReadOnlyCollection<IPlugin> Plugins { get; }
 
     [Obsolete]
     public INodeSessionCallback? SessionCallback { get; }
 
+    private readonly Func<CancellationToken, ValueTask>? onStartTransactionAsyncFunc;
+    private readonly Func<CancellationToken, ValueTask>? onEndTransactionAsyncFunc;
+
     public PluginProvider(
       IReadOnlyCollection<IPlugin> plugins,
 #pragma warning disable CS0618
-      INodeSessionCallback? sessionCallback
+      INodeSessionCallback? sessionCallback,
 #pragma warning restore CS0618
+      Func<CancellationToken, ValueTask>? onStartTransactionAsyncFunc,
+      Func<CancellationToken, ValueTask>? onEndTransactionAsyncFunc
     )
     {
       Plugins = plugins ?? throw new ArgumentNullException(nameof(plugins));
@@ -129,7 +149,16 @@ public class MuninNodeBuilder : IMuninNodeBuilder {
 #pragma warning disable CS0612
       SessionCallback = sessionCallback;
 #pragma warning restore CS0612
+
+      this.onStartTransactionAsyncFunc = onStartTransactionAsyncFunc;
+      this.onEndTransactionAsyncFunc = onEndTransactionAsyncFunc;
     }
+
+    public ValueTask StartTransactionAsync(CancellationToken cancellationToken)
+      => onStartTransactionAsyncFunc?.Invoke(cancellationToken) ?? default;
+
+    public ValueTask EndTransactionAsync(CancellationToken cancellationToken)
+      => onEndTransactionAsyncFunc?.Invoke(cancellationToken) ?? default;
   }
 
   protected virtual IMuninNode Build(

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilderExtensions.cs
@@ -106,7 +106,9 @@ public static class MuninNodeBuilderExtensions {
   /// </remarks>
   public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(
     this TMuninNodeBuilder builder,
+#pragma warning disable CS0618
     INodeSessionCallback sessionCallback
+#pragma warning restore CS0618
   )
     where TMuninNodeBuilder : MuninNodeBuilder
 #pragma warning restore CS0419
@@ -135,12 +137,15 @@ public static class MuninNodeBuilderExtensions {
 #pragma warning restore CS0419
     => UseSessionCallback(
       builder: builder,
+#pragma warning disable CS0612
       buildSessionCallback: _ => new SessionCallbackFuncWrapper(
         reportSessionStartedAsyncFunc,
         reportSessionClosedAsyncFunc
       )
+#pragma warning restore CS0612
     );
 
+  [Obsolete]
   private sealed class SessionCallbackFuncWrapper(
     Func<string, CancellationToken, ValueTask>? reportSessionStartedAsyncFunc,
     Func<string, CancellationToken, ValueTask>? reportSessionClosedAsyncFunc
@@ -162,7 +167,9 @@ public static class MuninNodeBuilderExtensions {
   /// </remarks>
   public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(
     this TMuninNodeBuilder builder,
+#pragma warning disable CS0618
     Func<IServiceProvider, INodeSessionCallback> buildSessionCallback
+#pragma warning restore CS0618
   )
     where TMuninNodeBuilder : MuninNodeBuilder
 #pragma warning restore CS0419
@@ -172,7 +179,9 @@ public static class MuninNodeBuilderExtensions {
     if (buildSessionCallback is null)
       throw new ArgumentNullException(nameof(buildSessionCallback));
 
+#pragma warning disable CS0612
     builder.SetSessionCallbackFactory(buildSessionCallback);
+#pragma warning restore CS0612
 
     return builder;
   }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilderExtensions.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/MuninNodeBuilderExtensions.cs
@@ -100,15 +100,20 @@ public static class MuninNodeBuilderExtensions {
     return builder;
   }
 
+#pragma warning disable CS0618
+  private const string ObsoleteMessageForUseSessionCallback =
+      $"{nameof(INodeSessionCallback)} is deprecated and will be removed in the next major version release. " +
+      $"Use ${nameof(UseTransactionCallback)} instead of {nameof(UseSessionCallback)}.";
+#pragma warning restore CS0618
+
 #pragma warning disable CS0419
   /// <remarks>
   /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
   /// </remarks>
+  [Obsolete(ObsoleteMessageForUseSessionCallback)]
   public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(
     this TMuninNodeBuilder builder,
-#pragma warning disable CS0618
     INodeSessionCallback sessionCallback
-#pragma warning restore CS0618
   )
     where TMuninNodeBuilder : MuninNodeBuilder
 #pragma warning restore CS0419
@@ -128,6 +133,7 @@ public static class MuninNodeBuilderExtensions {
   /// <remarks>
   /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
   /// </remarks>
+  [Obsolete(ObsoleteMessageForUseSessionCallback)]
   public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(
     this TMuninNodeBuilder builder,
     Func<string, CancellationToken, ValueTask>? reportSessionStartedAsyncFunc,
@@ -137,12 +143,10 @@ public static class MuninNodeBuilderExtensions {
 #pragma warning restore CS0419
     => UseSessionCallback(
       builder: builder,
-#pragma warning disable CS0612
       buildSessionCallback: _ => new SessionCallbackFuncWrapper(
         reportSessionStartedAsyncFunc,
         reportSessionClosedAsyncFunc
       )
-#pragma warning restore CS0612
     );
 
   [Obsolete]
@@ -165,11 +169,10 @@ public static class MuninNodeBuilderExtensions {
   /// <remarks>
   /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
   /// </remarks>
+  [Obsolete(ObsoleteMessageForUseSessionCallback)]
   public static TMuninNodeBuilder UseSessionCallback<TMuninNodeBuilder>(
     this TMuninNodeBuilder builder,
-#pragma warning disable CS0618
     Func<IServiceProvider, INodeSessionCallback> buildSessionCallback
-#pragma warning restore CS0618
   )
     where TMuninNodeBuilder : MuninNodeBuilder
 #pragma warning restore CS0419
@@ -179,9 +182,30 @@ public static class MuninNodeBuilderExtensions {
     if (buildSessionCallback is null)
       throw new ArgumentNullException(nameof(buildSessionCallback));
 
-#pragma warning disable CS0612
     builder.SetSessionCallbackFactory(buildSessionCallback);
-#pragma warning restore CS0612
+
+    return builder;
+  }
+
+#pragma warning disable CS0419
+  /// <remarks>
+  /// If <see cref="UsePluginProvider"/> is called, the configurations made by this method will be overridden.
+  /// </remarks>
+  public static TMuninNodeBuilder UseTransactionCallback<TMuninNodeBuilder>(
+    this TMuninNodeBuilder builder,
+    Func<CancellationToken, ValueTask>? onStartTransactionAsyncFunc,
+    Func<CancellationToken, ValueTask>? onEndTransactionAsyncFunc
+  )
+    where TMuninNodeBuilder : MuninNodeBuilder
+#pragma warning restore CS0419
+  {
+    if (builder is null)
+      throw new ArgumentNullException(nameof(builder));
+
+    builder.SetTransactionCallback(
+      onStartTransactionAsyncFunc,
+      onEndTransactionAsyncFunc
+    );
 
     return builder;
   }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/LocalNode.Create.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/LocalNode.Create.cs
@@ -20,6 +20,8 @@ partial class LocalNode {
 #pragma warning restore IDE0040
   private class ReadOnlyCollectionPluginProvider : IPluginProvider {
     public IReadOnlyCollection<IPlugin> Plugins { get; }
+
+    [Obsolete]
     public INodeSessionCallback? SessionCallback => null;
 
     public ReadOnlyCollectionPluginProvider(IReadOnlyCollection<IPlugin> plugins)

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
@@ -562,13 +562,14 @@ public abstract partial class NodeBase : IMuninNode, IMuninNodeProfile, IDisposa
       LogSessionStarted(Logger, null);
 
     try {
-      // TODO: rename INodeSessionCallback to ITransactionCallback
+#pragma warning disable CS0612,CS0618
       if (PluginProvider.SessionCallback is INodeSessionCallback pluginProviderSessionCallback)
         await pluginProviderSessionCallback.ReportSessionStartedAsync(sessionId, cancellationToken).ConfigureAwait(false);
 
       foreach (var pluginSessionCallback in EnumerateSessionCallbackForPlugins(PluginProvider)) {
         await pluginSessionCallback.ReportSessionStartedAsync(sessionId, cancellationToken).ConfigureAwait(false);
       }
+#pragma warning restore CS0612,CS0618
 
       // https://docs.microsoft.com/ja-jp/dotnet/standard/io/pipelines
       var pipe = new Pipe();
@@ -582,17 +583,22 @@ public abstract partial class NodeBase : IMuninNode, IMuninNodeProfile, IDisposa
         LogSessionClosed(Logger, null);
     }
     finally {
+#pragma warning disable CS0612,CS0618
       foreach (var pluginSessionCallback in EnumerateSessionCallbackForPlugins(PluginProvider)) {
         await pluginSessionCallback.ReportSessionClosedAsync(sessionId, cancellationToken).ConfigureAwait(false);
       }
 
       if (PluginProvider.SessionCallback is INodeSessionCallback pluginProviderSessionCallback)
         await pluginProviderSessionCallback.ReportSessionClosedAsync(sessionId, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CS0612,CS0618
 
       await protocolHandler.HandleTransactionEndAsync(client, cancellationToken).ConfigureAwait(false);
     }
 
+    [Obsolete]
+#pragma warning disable CS0618
     static IEnumerable<INodeSessionCallback> EnumerateSessionCallbackForPlugins(IPluginProvider pluginProvider)
+#pragma warning restore CS0618
     {
       foreach (var plugin in pluginProvider.EnumeratePlugins(flattenMultigraphPlugins: true)) {
         if (plugin.SessionCallback is INodeSessionCallback pluginSessionCallback)

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/INodeSessionCallback.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/INodeSessionCallback.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,6 +10,7 @@ namespace Smdn.Net.MuninPlugin;
 /// <summary>
 /// Defines the callbacks when a request session from the <c>munin-update</c> starts or ends.
 /// </summary>
+[Obsolete(message: ObsoleteMessage.TypeReference)]
 public interface INodeSessionCallback {
   /// <summary>
   /// Implements a callback to be called when <c>munin-update</c> starts a session.
@@ -25,4 +27,15 @@ public interface INodeSessionCallback {
   /// <param name="sessionId">A unique ID that <see cref="MuninNode.NodeBase"/> associates with the session.</param>
   /// <param name="cancellationToken">The <see cref="CancellationToken" /> to monitor for cancellation requests.</param>
   ValueTask ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken);
+
+  internal static class ObsoleteMessage {
+    public const string TypeReference =
+      $"{nameof(INodeSessionCallback)} is deprecated and will be removed in the next major version release. " +
+      $"Use ${nameof(ITransactionCallback)} interface instead.";
+
+    public const string SessionCallbackProperty =
+      $"{nameof(INodeSessionCallback)} is deprecated and will be removed in the next major version release. " +
+      $"Instead of setting an object that implements ${nameof(INodeSessionCallback)} to the property, " +
+      $"implement the ${nameof(ITransactionCallback)} interface to the type itself.";
+  }
 }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/IPlugin.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/IPlugin.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
 
+using System;
+
 namespace Smdn.Net.MuninPlugin;
 
 /// <summary>
@@ -25,5 +27,8 @@ public interface IPlugin {
   /// <remarks>Callbacks of this interface can be used to initiate bulk collection of field values.</remarks>
   /// <seealso cref="INodeSessionCallback"/>
   /// <seealso cref="MuninNode.NodeBase"/>
+#pragma warning disable CS0618
+  [Obsolete(message: INodeSessionCallback.ObsoleteMessage.SessionCallbackProperty)]
+#pragma warning restore CS0618
   INodeSessionCallback? SessionCallback { get; }
 }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/IPluginProvider.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/IPluginProvider.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
 
+using System;
 using System.Collections.Generic;
 
 namespace Smdn.Net.MuninPlugin;
@@ -21,5 +22,8 @@ public interface IPluginProvider {
   /// <summary>Gets a <see cref="INodeSessionCallback"/>, which defines the callbacks when a request session from the <c>munin-update</c> starts or ends, such as fetching data or getting configurations.</summary>
   /// <seealso cref="INodeSessionCallback"/>
   /// <seealso cref="MuninNode.NodeBase"/>
+#pragma warning disable CS0618
+  [Obsolete(message: INodeSessionCallback.ObsoleteMessage.SessionCallbackProperty)]
+#pragma warning restore CS0618
   INodeSessionCallback? SessionCallback { get; }
 }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/ITransactionCallback.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/ITransactionCallback.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System.Threading;
+using System.Threading.Tasks;
+
+using Smdn.Net.MuninNode.Protocol;
+
+namespace Smdn.Net.MuninPlugin;
+
+/// <summary>
+/// Defines the callbacks when a request session from the <c>munin-update</c> starts or ends.
+/// </summary>
+public interface ITransactionCallback {
+  /// <summary>
+  /// Implements a callback to be invoked when <c>munin-update</c> starts a transaction.
+  /// </summary>
+  /// <remarks>
+  /// This method is invoked when the <see cref="IMuninProtocolHandler"/> is requested to start
+  /// processing a transaction.
+  /// </remarks>
+  /// <param name="cancellationToken">
+  /// The <see cref="CancellationToken" /> to monitor for cancellation requests.
+  /// </param>
+  /// <seealso cref="IMuninProtocolHandler.HandleTransactionStartAsync"/>
+  ValueTask StartTransactionAsync(CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Implements a callback to be invoked when <c>munin-update</c> ends a transaction.
+  /// </summary>
+  /// <remarks>
+  /// This method is invoked when the <see cref="IMuninProtocolHandler"/> is requested to end
+  /// processing a transaction.
+  /// </remarks>
+  /// <param name="cancellationToken">
+  /// The <see cref="CancellationToken" /> to monitor for cancellation requests.
+  /// </param>
+  /// <seealso cref="Smdn.Net.MuninNode.Protocol.IMuninProtocolHandler.HandleTransactionEndAsync"/>
+  ValueTask EndTransactionAsync(CancellationToken cancellationToken);
+}

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/MultigraphPlugin.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/MultigraphPlugin.cs
@@ -19,6 +19,9 @@ public class MultigraphPlugin : IMultigraphPlugin {
   public IPluginGraphAttributes GraphAttributes => throw new NotSupportedException();
 
   /// <inheritdoc cref="IPlugin.SessionCallback"/>
+#pragma warning disable CS0618
+  [Obsolete(message: INodeSessionCallback.ObsoleteMessage.SessionCallbackProperty)]
+#pragma warning restore CS0618
   public INodeSessionCallback? SessionCallback => throw new NotSupportedException();
 
   public MultigraphPlugin(string name, IReadOnlyCollection<IPlugin> plugins)

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/Plugin.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/Plugin.cs
@@ -8,7 +8,16 @@ using System.Threading.Tasks;
 
 namespace Smdn.Net.MuninPlugin;
 
-public class Plugin : IPlugin, IPluginDataSource, INodeSessionCallback {
+#pragma warning disable IDE0055
+public class Plugin :
+  IPlugin,
+  IPluginDataSource,
+#pragma warning disable CS0618
+  INodeSessionCallback,
+#pragma warning restore CS0618
+  ITransactionCallback
+{
+#pragma warning restore IDE0055
   public string Name { get; }
 
   public PluginGraphAttributes GraphAttributes { get; }
@@ -21,6 +30,9 @@ public class Plugin : IPlugin, IPluginDataSource, INodeSessionCallback {
 
   IReadOnlyCollection<IPluginField> IPluginDataSource.Fields => Fields;
 
+#pragma warning disable CS0618
+  [Obsolete(message: INodeSessionCallback.ObsoleteMessage.SessionCallbackProperty)]
+#pragma warning restore CS0618
   INodeSessionCallback? IPlugin.SessionCallback => this;
 #pragma warning restore CA1033
 
@@ -37,15 +49,31 @@ public class Plugin : IPlugin, IPluginDataSource, INodeSessionCallback {
     Fields = fields ?? throw new ArgumentNullException(nameof(fields));
   }
 
+  [Obsolete]
   ValueTask INodeSessionCallback.ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken)
     => ReportSessionStartedAsync(sessionId, cancellationToken);
 
+  [Obsolete($"This method will be removed in the next major version release. Override {nameof(StartTransactionAsync)} instead.")]
   protected virtual ValueTask ReportSessionStartedAsync(string sessionId, CancellationToken cancellationToken)
     => default; // do nothing in this class
 
+  [Obsolete]
   ValueTask INodeSessionCallback.ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken)
     => ReportSessionClosedAsync(sessionId, cancellationToken);
 
+  [Obsolete($"This method will be removed in the next major version release. Override {nameof(EndTransactionAsync)} instead.")]
   protected virtual ValueTask ReportSessionClosedAsync(string sessionId, CancellationToken cancellationToken)
+    => default; // do nothing in this class
+
+  ValueTask ITransactionCallback.StartTransactionAsync(CancellationToken cancellationToken)
+    => StartTransactionAsync(cancellationToken);
+
+  protected virtual ValueTask StartTransactionAsync(CancellationToken cancellationToken)
+    => default; // do nothing in this class
+
+  ValueTask ITransactionCallback.EndTransactionAsync(CancellationToken cancellationToken)
+    => EndTransactionAsync(cancellationToken);
+
+  protected virtual ValueTask EndTransactionAsync(CancellationToken cancellationToken)
     => default; // do nothing in this class
 }

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/PluginFactory.Plugin.cs
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/PluginFactory.Plugin.cs
@@ -16,6 +16,8 @@ partial class PluginFactory {
     public IReadOnlyCollection<IPluginField> Fields { get; }
 
     public IPluginDataSource DataSource => this;
+
+    [Obsolete]
     public INodeSessionCallback? SessionCallback => null;
 
     public DefaultPlugin(

--- a/tests/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/MuninNodeBackgroundService.cs
+++ b/tests/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting/MuninNodeBackgroundService.cs
@@ -134,7 +134,7 @@ public class MuninNodeBackgroundServiceTests {
 
   private class EmptyPluginProvider : IPluginProvider {
     public IReadOnlyCollection<IPlugin> Plugins { get; } = [];
-    public INodeSessionCallback? SessionCallback => null;
+    [Obsolete] public INodeSessionCallback? SessionCallback => null;
   }
 
   private class EmptyNode : LocalNode {

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.DependencyInjection/IMuninNodeBuilderExtensions.cs
@@ -51,7 +51,7 @@ public class IMuninNodeBuilderExtensionsTests {
     public string Name => "pseudo-plugin";
     public IPluginGraphAttributes GraphAttributes => throw new NotImplementedException();
     public IPluginDataSource DataSource => throw new NotImplementedException();
-    public INodeSessionCallback? SessionCallback => null;
+    [Obsolete] public INodeSessionCallback? SessionCallback => null;
   }
 
   [Test]
@@ -161,7 +161,7 @@ public class IMuninNodeBuilderExtensionsTests {
   private class PseudoPluginProvider(IServiceProvider? serviceProvider = null) : IPluginProvider {
     public IServiceProvider? ServiceProvider => serviceProvider;
     public IReadOnlyCollection<IPlugin> Plugins => throw new NotImplementedException();
-    public INodeSessionCallback? SessionCallback => throw new NotImplementedException();
+    [Obsolete] public INodeSessionCallback? SessionCallback => throw new NotImplementedException();
   }
 
   [Test]
@@ -184,10 +184,12 @@ public class IMuninNodeBuilderExtensionsTests {
       () => _ = node.PluginProvider.Plugins,
       Throws.TypeOf<NotImplementedException>()
     );
+#pragma warning disable CS0618
     Assert.That(
       () => _ = node.PluginProvider.SessionCallback,
       Throws.TypeOf<NotImplementedException>()
     );
+#pragma warning restore CS0618
   }
 
   [Test]
@@ -273,6 +275,7 @@ public class IMuninNodeBuilderExtensionsTests {
     );
   }
 
+#pragma warning disable CS0618
   private class SessionCallback(IServiceProvider? serviceProvider = null) : INodeSessionCallback {
     public IServiceProvider? ServiceProvider => serviceProvider;
 
@@ -302,7 +305,9 @@ public class IMuninNodeBuilderExtensionsTests {
     Assert.That(node.PluginProvider.SessionCallback, Is.Not.Null);
     Assert.That(node.PluginProvider.SessionCallback, Is.SameAs(sessionCallback));
   }
+#pragma warning restore CS0618
 
+#pragma warning disable CS0618
   private static System.Collections.IEnumerable YieldTestCases_UseSessionCallback_FuncSessionCallback()
   {
     yield return new object[] {
@@ -391,6 +396,7 @@ public class IMuninNodeBuilderExtensionsTests {
 
     assertBuiltNode(node);
   }
+#pragma warning restore CS0618
 
   [Test]
   public void UseSessionCallback_FuncBuildSessionCallback_ArgumentNull()
@@ -420,6 +426,7 @@ public class IMuninNodeBuilderExtensionsTests {
     );
   }
 
+#pragma warning disable CS0618
   [Test]
   public void UseSessionCallback_FuncBuildSessionCallback()
   {
@@ -445,6 +452,7 @@ public class IMuninNodeBuilderExtensionsTests {
     Assert.That(sessionCallback!.ServiceProvider, Is.Not.Null);
     Assert.That(sessionCallback!.ServiceProvider!.GetRequiredService<IMuninNode>, Throws.Nothing);
   }
+#pragma warning restore CS0618
 
   [Test]
   public void UseListenerFactory_IMuninNodeListenerFactory_ArgumentNull()

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.Protocol/MuninProtocolHandler.Transaction.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.Protocol/MuninProtocolHandler.Transaction.cs
@@ -15,9 +15,11 @@ namespace Smdn.Net.MuninNode.Protocol;
 #pragma warning disable IDE0040
 partial class MuninProtocolHandlerTests {
 #pragma warning restore IDE0040
+  // TODO: Plugin
+  // TODO: AggregatePluginProvider
   private class TransactionCallbackPluginProvider : IPluginProvider, ITransactionCallback {
     public IReadOnlyCollection<IPlugin> Plugins => Array.Empty<IPlugin>();
-    public INodeSessionCallback? SessionCallback => null;
+    [Obsolete]  public INodeSessionCallback? SessionCallback => null;
 
     public Action<CancellationToken>? OnStartTransaction { get; init; }
     public Action<CancellationToken>? OnEndTransaction { get; init; }
@@ -107,7 +109,7 @@ partial class MuninProtocolHandlerTests {
     public string Name => name;
     public IPluginGraphAttributes GraphAttributes => throw new NotImplementedException();
     public IPluginDataSource DataSource => throw new NotImplementedException();
-    public INodeSessionCallback? SessionCallback => throw new NotImplementedException();
+    [Obsolete] public INodeSessionCallback? SessionCallback => throw new NotImplementedException();
 
     public Action<CancellationToken>? OnStartTransaction { get; init; }
     public Action<CancellationToken>? OnEndTransaction { get; init; }
@@ -201,7 +203,7 @@ partial class MuninProtocolHandlerTests {
     public string Name => name;
     public IPluginGraphAttributes GraphAttributes => throw new NotImplementedException();
     public IPluginDataSource DataSource => throw new NotImplementedException();
-    public INodeSessionCallback? SessionCallback => throw new NotImplementedException();
+    [Obsolete] public INodeSessionCallback? SessionCallback => throw new NotImplementedException();
     public IReadOnlyCollection<IPlugin> Plugins { get; } = [plugin];
 
     public Action<CancellationToken>? OnStartTransaction { get; init; }

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.Protocol/MuninProtocolHandler.Transaction.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.Protocol/MuninProtocolHandler.Transaction.cs
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: 2025 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using Smdn.Net.MuninPlugin;
+
+namespace Smdn.Net.MuninNode.Protocol;
+
+#pragma warning disable IDE0040
+partial class MuninProtocolHandlerTests {
+#pragma warning restore IDE0040
+  private class TransactionCallbackPluginProvider : IPluginProvider, ITransactionCallback {
+    public IReadOnlyCollection<IPlugin> Plugins => Array.Empty<IPlugin>();
+    public INodeSessionCallback? SessionCallback => null;
+
+    public Action<CancellationToken>? OnStartTransaction { get; init; }
+    public Action<CancellationToken>? OnEndTransaction { get; init; }
+
+    public ValueTask StartTransactionAsync(CancellationToken cancellationToken)
+    {
+      OnStartTransaction?.Invoke(cancellationToken);
+
+      return default;
+    }
+
+    public ValueTask EndTransactionAsync(CancellationToken cancellationToken)
+    {
+      OnEndTransaction?.Invoke(cancellationToken);
+
+      return default;
+    }
+  }
+
+  [Test]
+  [CancelAfter(1000)]
+  public void HandleTransactionStartAsync_ITransactionCallback_IPluginProvider(CancellationToken cancellationToken)
+  {
+    const string HostName = "munin-node.localhost";
+
+    var numberOfOnStartTransactionInvoked = 0;
+    var numberOfOnEndTransactionInvoked = 0;
+    var handler = new MuninProtocolHandler(
+      profile: new MuninNodeProfile() {
+        HostName = HostName,
+        PluginProvider = new TransactionCallbackPluginProvider() {
+          OnStartTransaction = ct => {
+            Assert.That(ct, Is.EqualTo(cancellationToken));
+            numberOfOnStartTransactionInvoked++;
+          },
+          OnEndTransaction = ct => {
+            Assert.That(ct, Is.EqualTo(cancellationToken));
+            numberOfOnEndTransactionInvoked++;
+          }
+        }
+      }
+    );
+    var client = new PseudoMuninNodeClient();
+
+    Assert.That(
+      async () => await handler.HandleTransactionStartAsync(client, cancellationToken),
+      Throws.Nothing
+    );
+    Assert.That(numberOfOnStartTransactionInvoked, Is.EqualTo(1));
+    Assert.That(numberOfOnEndTransactionInvoked, Is.Zero);
+  }
+
+  [Test]
+  [CancelAfter(1000)]
+  public void HandleTransactionEndAsync_ITransactionCallback_IPluginProvider(CancellationToken cancellationToken)
+  {
+    const string HostName = "munin-node.localhost";
+
+    var numberOfOnStartTransactionInvoked = 0;
+    var numberOfOnEndTransactionInvoked = 0;
+    var handler = new MuninProtocolHandler(
+      profile: new MuninNodeProfile() {
+        HostName = HostName,
+        PluginProvider = new TransactionCallbackPluginProvider() {
+          OnStartTransaction = ct => {
+            Assert.That(ct, Is.EqualTo(cancellationToken));
+            numberOfOnStartTransactionInvoked++;
+          },
+          OnEndTransaction = ct => {
+            Assert.That(ct, Is.EqualTo(cancellationToken));
+            numberOfOnEndTransactionInvoked++;
+          }
+        }
+      }
+    );
+    var client = new PseudoMuninNodeClient();
+
+    Assert.That(
+      async () => await handler.HandleTransactionEndAsync(client, cancellationToken),
+      Throws.Nothing
+    );
+    Assert.That(numberOfOnStartTransactionInvoked, Is.Zero);
+    Assert.That(numberOfOnEndTransactionInvoked, Is.EqualTo(1));
+  }
+
+  private class TransactionCallbackPlugin(string name) : IPlugin, ITransactionCallback {
+    public string Name => name;
+    public IPluginGraphAttributes GraphAttributes => throw new NotImplementedException();
+    public IPluginDataSource DataSource => throw new NotImplementedException();
+    public INodeSessionCallback? SessionCallback => throw new NotImplementedException();
+
+    public Action<CancellationToken>? OnStartTransaction { get; init; }
+    public Action<CancellationToken>? OnEndTransaction { get; init; }
+
+    public ValueTask StartTransactionAsync(CancellationToken cancellationToken)
+    {
+      OnStartTransaction?.Invoke(cancellationToken);
+
+      return default;
+    }
+
+    public ValueTask EndTransactionAsync(CancellationToken cancellationToken)
+    {
+      OnEndTransaction?.Invoke(cancellationToken);
+
+      return default;
+    }
+  }
+
+  [Test]
+  [CancelAfter(1000)]
+  public void HandleTransactionStartAsync_ITransactionCallback_IPlugin(CancellationToken cancellationToken)
+  {
+    const string HostName = "munin-node.localhost";
+
+    var numberOfOnStartTransactionInvoked = 0;
+    var numberOfOnEndTransactionInvoked = 0;
+    var handler = new MuninProtocolHandler(
+      profile: new MuninNodeProfile() {
+        HostName = HostName,
+        PluginProvider = new PluginProvider([
+          new TransactionCallbackPlugin("plugin") {
+            OnStartTransaction = ct => {
+              Assert.That(ct, Is.EqualTo(cancellationToken));
+              numberOfOnStartTransactionInvoked++;
+            },
+            OnEndTransaction = ct => {
+              Assert.That(ct, Is.EqualTo(cancellationToken));
+              numberOfOnEndTransactionInvoked++;
+            }
+          }
+        ])
+      }
+    );
+    var client = new PseudoMuninNodeClient();
+
+    Assert.That(
+      async () => await handler.HandleTransactionStartAsync(client, cancellationToken),
+      Throws.Nothing
+    );
+    Assert.That(numberOfOnStartTransactionInvoked, Is.EqualTo(1));
+    Assert.That(numberOfOnEndTransactionInvoked, Is.Zero);
+  }
+
+  [Test]
+  [CancelAfter(1000)]
+  public void HandleTransactionEndAsync_ITransactionCallback_IPlugin(CancellationToken cancellationToken)
+  {
+    const string HostName = "munin-node.localhost";
+
+    var numberOfOnStartTransactionInvoked = 0;
+    var numberOfOnEndTransactionInvoked = 0;
+    var handler = new MuninProtocolHandler(
+      profile: new MuninNodeProfile() {
+        HostName = HostName,
+        PluginProvider = new PluginProvider([
+          new TransactionCallbackPlugin("plugin") {
+            OnStartTransaction = ct => {
+              Assert.That(ct, Is.EqualTo(cancellationToken));
+              numberOfOnStartTransactionInvoked++;
+            },
+            OnEndTransaction = ct => {
+              Assert.That(ct, Is.EqualTo(cancellationToken));
+              numberOfOnEndTransactionInvoked++;
+            }
+          }
+        ])
+      }
+    );
+    var client = new PseudoMuninNodeClient();
+
+    Assert.That(
+      async () => await handler.HandleTransactionEndAsync(client, cancellationToken),
+      Throws.Nothing
+    );
+    Assert.That(numberOfOnStartTransactionInvoked, Is.Zero);
+    Assert.That(numberOfOnEndTransactionInvoked, Is.EqualTo(1));
+  }
+
+  private class TransactionCallbackMultigraphPlugin(string name, IPlugin plugin) : IMultigraphPlugin, ITransactionCallback {
+    public string Name => name;
+    public IPluginGraphAttributes GraphAttributes => throw new NotImplementedException();
+    public IPluginDataSource DataSource => throw new NotImplementedException();
+    public INodeSessionCallback? SessionCallback => throw new NotImplementedException();
+    public IReadOnlyCollection<IPlugin> Plugins { get; } = [plugin];
+
+    public Action<CancellationToken>? OnStartTransaction { get; init; }
+    public Action<CancellationToken>? OnEndTransaction { get; init; }
+
+    public ValueTask StartTransactionAsync(CancellationToken cancellationToken)
+    {
+      OnStartTransaction?.Invoke(cancellationToken);
+
+      return default;
+    }
+
+    public ValueTask EndTransactionAsync(CancellationToken cancellationToken)
+    {
+      OnEndTransaction?.Invoke(cancellationToken);
+
+      return default;
+    }
+  }
+
+  [Test]
+  [CancelAfter(1000)]
+  public void HandleTransactionStartAsync_ITransactionCallback_IMultigraphPlugin(
+    [Values] bool multigraph,
+    CancellationToken cancellationToken
+  )
+  {
+    const string HostName = "munin-node.localhost";
+
+    var numberOfMultigraphPluginOnStartTransactionInvoked = 0;
+    var numberOfMultigraphPluginOnEndTransactionInvoked = 0;
+    var numberOfPluginOnStartTransactionInvoked = 0;
+    var numberOfPluginOnEndTransactionInvoked = 0;
+    var handler = new MuninProtocolHandler(
+      profile: new MuninNodeProfile() {
+        HostName = HostName,
+        PluginProvider = new PluginProvider([
+          new TransactionCallbackMultigraphPlugin(
+            "multigraph_plugin",
+            new TransactionCallbackPlugin("plugin") {
+              OnStartTransaction = ct => {
+                Assert.That(ct, Is.EqualTo(cancellationToken));
+                numberOfPluginOnStartTransactionInvoked++;
+              },
+              OnEndTransaction = ct => {
+                Assert.That(ct, Is.EqualTo(cancellationToken));
+                numberOfPluginOnEndTransactionInvoked++;
+              }
+            }
+          ) {
+            OnStartTransaction = ct => {
+              Assert.That(ct, Is.EqualTo(cancellationToken));
+              numberOfMultigraphPluginOnStartTransactionInvoked++;
+            },
+            OnEndTransaction = ct => {
+              Assert.That(ct, Is.EqualTo(cancellationToken));
+              numberOfMultigraphPluginOnEndTransactionInvoked++;
+            }
+          }
+        ])
+      }
+    );
+    var client = new PseudoMuninNodeClient();
+
+    if (multigraph) {
+      Assert.That(
+        async () => await handler.HandleCommandAsync(
+          client,
+          commandLine: CreateCommandLineSequence("cap multigraph")
+        ),
+        Throws.Nothing
+      );
+    }
+
+    Assert.That(
+      async () => await handler.HandleTransactionStartAsync(client, cancellationToken),
+      Throws.Nothing
+    );
+    Assert.That(numberOfMultigraphPluginOnStartTransactionInvoked, multigraph ? Is.EqualTo(1) : Is.Zero);
+    Assert.That(numberOfMultigraphPluginOnEndTransactionInvoked, Is.Zero);
+    Assert.That(numberOfPluginOnStartTransactionInvoked, multigraph ? Is.Zero : Is.EqualTo(1));
+    Assert.That(numberOfPluginOnEndTransactionInvoked, Is.Zero);
+  }
+
+  [Test]
+  [CancelAfter(1000)]
+  public void HandleTransactionEndAsync_ITransactionCallback_IMultigraphPlugin(
+    [Values] bool multigraph,
+    CancellationToken cancellationToken
+  )
+  {
+    const string HostName = "munin-node.localhost";
+
+    var numberOfMultigraphPluginOnStartTransactionInvoked = 0;
+    var numberOfMultigraphPluginOnEndTransactionInvoked = 0;
+    var numberOfPluginOnStartTransactionInvoked = 0;
+    var numberOfPluginOnEndTransactionInvoked = 0;
+    var handler = new MuninProtocolHandler(
+      profile: new MuninNodeProfile() {
+        HostName = HostName,
+        PluginProvider = new PluginProvider([
+          new TransactionCallbackMultigraphPlugin(
+            "multigraph_plugin",
+            new TransactionCallbackPlugin("plugin") {
+              OnStartTransaction = ct => {
+                Assert.That(ct, Is.EqualTo(cancellationToken));
+                numberOfPluginOnStartTransactionInvoked++;
+              },
+              OnEndTransaction = ct => {
+                Assert.That(ct, Is.EqualTo(cancellationToken));
+                numberOfPluginOnEndTransactionInvoked++;
+              }
+            }
+          ) {
+            OnStartTransaction = ct => {
+              Assert.That(ct, Is.EqualTo(cancellationToken));
+              numberOfMultigraphPluginOnStartTransactionInvoked++;
+            },
+            OnEndTransaction = ct => {
+              Assert.That(ct, Is.EqualTo(cancellationToken));
+              numberOfMultigraphPluginOnEndTransactionInvoked++;
+            }
+          }
+        ])
+      }
+    );
+    var client = new PseudoMuninNodeClient();
+
+    if (multigraph) {
+      Assert.That(
+        async () => await handler.HandleCommandAsync(
+          client,
+          commandLine: CreateCommandLineSequence("cap multigraph")
+        ),
+        Throws.Nothing
+      );
+    }
+
+    Assert.That(
+      async () => await handler.HandleTransactionEndAsync(client, cancellationToken),
+      Throws.Nothing
+    );
+    Assert.That(numberOfMultigraphPluginOnStartTransactionInvoked, Is.Zero);
+    Assert.That(numberOfMultigraphPluginOnEndTransactionInvoked, multigraph ? Is.EqualTo(1) : Is.Zero);
+    Assert.That(numberOfPluginOnStartTransactionInvoked, Is.Zero);
+    Assert.That(numberOfPluginOnEndTransactionInvoked, multigraph ? Is.Zero : Is.EqualTo(1));
+  }
+}

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.Protocol/MuninProtocolHandler.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode.Protocol/MuninProtocolHandler.cs
@@ -21,7 +21,7 @@ namespace Smdn.Net.MuninNode.Protocol;
 public partial class MuninProtocolHandlerTests {
   private class PluginProvider(IReadOnlyCollection<IPlugin> plugins) : IPluginProvider {
     public IReadOnlyCollection<IPlugin> Plugins { get; } = plugins;
-    public INodeSessionCallback? SessionCallback => null;
+    [Obsolete] public INodeSessionCallback? SessionCallback => null;
   }
 
   private class EmptyPluginProvider() : PluginProvider(plugins: Array.Empty<IPlugin>()) { }

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.Accept.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.Accept.cs
@@ -198,11 +198,12 @@ public partial class NodeBaseTests {
     });
   }
 
+#pragma warning disable CS0618
   private class PseudoPluginProviderWithSessionCallback : IPluginProvider, INodeSessionCallback {
     public IReadOnlyCollection<IPlugin> Plugins { get; }
 
     private readonly bool setSessionCallbackNull;
-    public INodeSessionCallback? SessionCallback => setSessionCallbackNull ? null : this;
+    [Obsolete] public INodeSessionCallback? SessionCallback => setSessionCallbackNull ? null : this;
     public List<string> StartedSessionIds { get; } = new();
     public List<string> ClosedSessionIds { get; } = new();
 
@@ -233,7 +234,7 @@ public partial class NodeBaseTests {
     public IPluginDataSource DataSource => throw new NotImplementedException();
 
     private readonly bool setSessionCallbackNull;
-    public INodeSessionCallback? SessionCallback => setSessionCallbackNull ? null : this;
+    [Obsolete] public INodeSessionCallback? SessionCallback => setSessionCallbackNull ? null : this;
     public List<string> StartedSessionIds { get; } = new();
     public List<string> ClosedSessionIds { get; } = new();
 
@@ -256,7 +257,9 @@ public partial class NodeBaseTests {
       return default;
     }
   }
+#pragma warning restore CS0618
 
+#pragma warning disable CS0612
   [Test]
   public async Task AcceptSingleSessionAsync_INodeSessionCallback(
     [Values] bool setPluginProviderSessionCallbackNull,
@@ -343,6 +346,7 @@ public partial class NodeBaseTests {
       Assert.That(plugin.ClosedSessionIds[0], Is.Not.Empty, nameof(plugin.ClosedSessionIds));
     }
   }
+#pragma warning restore CS0612
 
   [TestCase(true)]
   [TestCase(false)]

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.Commands.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.Commands.cs
@@ -45,7 +45,7 @@ partial class NodeBaseTests {
 
     private class ReadOnlyCollectionPluginProvider : IPluginProvider {
       public IReadOnlyCollection<IPlugin> Plugins { get; }
-      public INodeSessionCallback? SessionCallback => null;
+      [Obsolete] public INodeSessionCallback? SessionCallback => null;
 
       public ReadOnlyCollectionPluginProvider(IReadOnlyCollection<IPlugin> plugins)
       {

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninNode/NodeBase.cs
@@ -22,7 +22,7 @@ public partial class NodeBaseTests {
   private class TestLocalNode : LocalNode {
     private class ReadOnlyCollectionPluginProvider : IPluginProvider {
       public IReadOnlyCollection<IPlugin> Plugins { get; }
-      public INodeSessionCallback? SessionCallback => null;
+      [Obsolete] public INodeSessionCallback? SessionCallback => null;
 
       public ReadOnlyCollectionPluginProvider(IReadOnlyCollection<IPlugin> plugins)
       {
@@ -78,7 +78,7 @@ public partial class NodeBaseTests {
 
     private class NullPluginProvider : IPluginProvider {
       public IReadOnlyCollection<IPlugin> Plugins { get; } = [];
-      public INodeSessionCallback? SessionCallback => null;
+      [Obsolete] public INodeSessionCallback? SessionCallback => null;
     }
 
     public override IPluginProvider PluginProvider { get; } = new NullPluginProvider();

--- a/tests/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/AggregatePluginProvider.cs
+++ b/tests/Smdn.Net.MuninNode/Smdn.Net.MuninPlugin/AggregatePluginProvider.cs
@@ -16,12 +16,14 @@ public class AggregatePluginProviderTests {
     public string Name { get; } = name;
     public IPluginGraphAttributes GraphAttributes => throw new NotImplementedException();
     public IPluginDataSource DataSource => throw new NotImplementedException();
-    public INodeSessionCallback? SessionCallback => null;
+    [Obsolete] public INodeSessionCallback? SessionCallback => null;
   }
 
+#pragma warning disable CS0618
   private class PseudoPluginProvider(IReadOnlyCollection<IPlugin> plugins) : IPluginProvider, INodeSessionCallback {
+#pragma warning restore CS0618
     public IReadOnlyCollection<IPlugin> Plugins => plugins;
-    public INodeSessionCallback? SessionCallback => this;
+    [Obsolete] public INodeSessionCallback? SessionCallback => this;
 
     public int NumberOfInvocationOfReportSessionStartedAsync = 0;
     public int NumberOfInvocationOfReportSessionClosedAsync = 0;
@@ -135,6 +137,7 @@ public class AggregatePluginProviderTests {
     Assert.That(pluginProviderCollections.Plugins.Select(static p => p.Name), Is.EquivalentTo(["#1", "#2", "#3"]));
   }
 
+#pragma warning disable CS0618
   [Test]
   public void INodeSessionCallback_ReportSessionStartedAsync()
   {
@@ -158,7 +161,9 @@ public class AggregatePluginProviderTests {
     Assert.That(provider2.NumberOfInvocationOfReportSessionStartedAsync, Is.EqualTo(1));
     Assert.That(provider2.NumberOfInvocationOfReportSessionClosedAsync, Is.Zero);
   }
+#pragma warning restore CS0618
 
+#pragma warning disable CS0618
   [Test]
   public void INodeSessionCallback_ReportSessionClosedAsync()
   {
@@ -182,7 +187,9 @@ public class AggregatePluginProviderTests {
     Assert.That(provider2.NumberOfInvocationOfReportSessionStartedAsync, Is.Zero);
     Assert.That(provider2.NumberOfInvocationOfReportSessionClosedAsync, Is.EqualTo(1));
   }
+#pragma warning restore CS0618
 
+#pragma warning disable CS0618
   [Test]
   public void INodeSessionCallback_ReportSessionStartedAsync_CancellationRequested()
   {
@@ -206,7 +213,9 @@ public class AggregatePluginProviderTests {
     Assert.That(provider2.NumberOfInvocationOfReportSessionStartedAsync, Is.Zero);
     Assert.That(provider2.NumberOfInvocationOfReportSessionClosedAsync, Is.Zero);
   }
+#pragma warning restore CS0618
 
+#pragma warning disable CS0618
   [Test]
   public void INodeSessionCallback_ReportSessionClosedAsync_CancellationRequested()
   {
@@ -230,4 +239,5 @@ public class AggregatePluginProviderTests {
     Assert.That(provider2.NumberOfInvocationOfReportSessionStartedAsync, Is.Zero);
     Assert.That(provider2.NumberOfInvocationOfReportSessionClosedAsync, Is.Zero);
   }
+#pragma warning restore CS0618
 }


### PR DESCRIPTION
### Description
This PR introduces a new interface, `ITransactionCallback`.
The main motives for introducing this interface are the following four.

- Provide a simpler approach than `INodeSessionCallback`
- Decoupling of `NodeBase` and transaction callbacks
- Discontinue the Session ID feature in `NodeBase`
- Replace "session" with "transaction," a term used in Munin documents

This interface provides a mechanism for calling back at the start and end of a request by munin-update.
Unlike the existing `INodeSessionCallback`, it can be implemented in any type together with `IPluginProvider` or `IPlugin`.
In addition, callbacks are changed to be triggered from `IMuninProtocolHandler` rather than directly from `NodeBase`.

`INodeSessionCallback` is now obsolete and will be deprecated in the next major release.
Due to this, the following features will also be deprecated.
- Session ID functionality in `NodeBase`
- `SessionCallback` property provided by `IPluginProvider` and `IPlugin`