### PR TITLE
Support AOT compilation

### DIFF
--- a/examples/Smdn.Net.MuninNode.Hosting/getting-started/Program.csproj
+++ b/examples/Smdn.Net.MuninNode.Hosting/getting-started/Program.csproj
@@ -6,10 +6,14 @@ SPDX-License-Identifier: MIT
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishRelease>true</PublishRelease>
+    <StripSymbols>true</StripSymbols>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-    <PackageReference Include="Smdn.Net.MuninNode.Hosting" Version="3.1.0" />
+    <PackageReference Include="Smdn.Net.MuninNode.Hosting" Version="3.3.0" />
   </ItemGroup>
 </Project>

--- a/examples/Smdn.Net.MuninNode/getting-started/Program.csproj
+++ b/examples/Smdn.Net.MuninNode/getting-started/Program.csproj
@@ -6,10 +6,14 @@ SPDX-License-Identifier: MIT
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishRelease>true</PublishRelease>
+    <StripSymbols>true</StripSymbols>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-    <PackageReference Include="Smdn.Net.MuninNode" Version="2.3.0" />
+    <PackageReference Include="Smdn.Net.MuninNode" Version="2.7.0" />
   </ItemGroup>
 </Project>

--- a/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting.csproj
+++ b/src/Smdn.Net.MuninNode.Hosting/Smdn.Net.MuninNode.Hosting.csproj
@@ -9,8 +9,6 @@ SPDX-License-Identifier: MIT
     <VersionSuffix></VersionSuffix>
     <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
     <NoWarn>CS1591;$(NoWarn)</NoWarn> <!-- CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member' -->
-    <IsAotCompatible>false</IsAotCompatible>
-    <VerifyReferenceAotCompatibility>false</VerifyReferenceAotCompatibility>
   </PropertyGroup>
 
   <PropertyGroup Label="assembly attributes">
@@ -33,8 +31,8 @@ This library uses [Smdn.Net.MuninNode](https://www.nuget.org/packages/Smdn.Net.M
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <ProjectOrPackageReference ReferencePackageVersion="[2.5.0,4.0.0)" Include="..\Smdn.Net.MuninNode\Smdn.Net.MuninNode.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <ProjectOrPackageReference ReferencePackageVersion="[2.7.0,4.0.0)" Include="..\Smdn.Net.MuninNode\Smdn.Net.MuninNode.csproj" />
   </ItemGroup>
 
   <Target Name="GenerateReadmeFileContent">

--- a/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.csproj
+++ b/src/Smdn.Net.MuninNode/Smdn.Net.MuninNode.csproj
@@ -9,8 +9,6 @@ SPDX-License-Identifier: MIT
     <VersionSuffix></VersionSuffix>
     <PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>
     <NoWarn>CS1591;$(NoWarn)</NoWarn> <!-- CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member' -->
-    <IsAotCompatible>false</IsAotCompatible>
-    <VerifyReferenceAotCompatibility>false</VerifyReferenceAotCompatibility>
   </PropertyGroup>
 
   <PropertyGroup Label="assembly attributes">
@@ -31,10 +29,10 @@ This library also provides abstraction APIs for implementing Munin-Plugin. By us
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageReference Include="Smdn.Fundamental.Encoding.Buffer" Version="[3.0.0,4.0.0)" Condition="$(TargetFramework.StartsWith('net4')) or $(TargetFramework.StartsWith('netstandard'))" />
     <PackageReference Include="Smdn.Fundamental.Exception" Version="[3.0.0,4.0.0)" Condition="$(TargetFramework.StartsWith('netstandard'))" />
   </ItemGroup>


### PR DESCRIPTION
### Description
This PR updates the dependency packages to AOT-compatible versions and re-enables `IsAotCompatible` property, which had previously been disabled.
As a result, the package itself becomes AOT-compatible.

The `getting-started` examples are also updated so that it can be published as a single-file native AOT application using `dotnet publish -r`.
